### PR TITLE
Load local deploy env from files with CI fallback

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -129,6 +129,7 @@ npm run build:cf
 ```bash
 npm run deploy:cf:prod
 ```
+This command loads runtime vars from `.env` (local deploy path).
 6. Set remaining env vars in Worker settings:
 - `DATABASE_URL`
 - `APP_BASE_URL`
@@ -138,6 +139,7 @@ Dev deploy command:
 ```bash
 npm run deploy:cf:dev
 ```
+This command loads runtime vars from `.env.local` (local dev path).
 
 Per-environment secret update:
 ```bash

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -28,6 +28,9 @@ npm run check:env:dev
 Local file rule:
 - Use `.env.local` for local development values.
 - Do not rely on `.env` for active local runtime configuration.
+- Local dev deploy commands (`deploy:cf:dev`, `preview:cf`) load from `.env.local`.
+- Local prod deploy command (`deploy:cf:prod`) loads from `.env`.
+- In CI, these commands fall back to already-injected environment variables when env files are absent.
 
 ## 3. Required Variables
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "db:migrate": "drizzle-kit migrate --config=drizzle.config.ts",
     "db:studio": "drizzle-kit studio --config=drizzle.config.ts",
     "build:cf": "opennextjs-cloudflare build",
-    "preview:cf": "opennextjs-cloudflare build && wrangler dev --env dev",
+    "preview:cf": "node scripts/run-with-env.mjs --file .env.local --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env.local --optional -- wrangler dev --env dev",
     "deploy:cf": "npm run deploy:cf:prod",
-    "deploy:cf:dev": "opennextjs-cloudflare build && wrangler deploy --env dev .open-next/worker.js",
-    "deploy:cf:prod": "opennextjs-cloudflare build && wrangler deploy --env prod .open-next/worker.js"
+    "deploy:cf:dev": "node scripts/run-with-env.mjs --file .env.local --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env.local --optional -- wrangler deploy --env dev .open-next/worker.js",
+    "deploy:cf:prod": "node scripts/run-with-env.mjs --file .env --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env --optional -- wrangler deploy --env prod .open-next/worker.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.987.0",

--- a/scripts/run-with-env.mjs
+++ b/scripts/run-with-env.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+function parseArgs(argv) {
+  const sep = argv.indexOf('--');
+  if (sep === -1) {
+    throw new Error('Usage: node scripts/run-with-env.mjs --file <env-file> -- <command> [args...]');
+  }
+
+  const optionArgs = argv.slice(0, sep);
+  const commandArgs = argv.slice(sep + 1);
+  if (commandArgs.length === 0) {
+    throw new Error('Missing command after --');
+  }
+
+  let file = null;
+  let optional = false;
+  for (let i = 0; i < optionArgs.length; i += 1) {
+    const arg = optionArgs[i];
+    if (arg === '--file') {
+      file = optionArgs[i + 1] ?? null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--optional') {
+      optional = true;
+    }
+  }
+
+  if (!file) {
+    throw new Error('Missing --file <env-file>');
+  }
+
+  return { file, commandArgs, optional };
+}
+
+function parseDotenv(content) {
+  const map = new Map();
+  const lines = content.split(/\r?\n/);
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+
+    const key = match[1];
+    let value = match[2] ?? '';
+
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    map.set(key, value);
+  }
+
+  return map;
+}
+
+function loadEnvFromFile(filePath, optional) {
+  const absolute = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(absolute)) {
+    if (optional) return { ...process.env };
+    throw new Error(`Env file not found: ${absolute}`);
+  }
+
+  const content = fs.readFileSync(absolute, 'utf8');
+  const vars = parseDotenv(content);
+  const merged = { ...process.env };
+
+  for (const [key, value] of vars.entries()) {
+    merged[key] = value;
+  }
+
+  return merged;
+}
+
+function run(commandArgs, env) {
+  const [command, ...args] = commandArgs;
+  const child = spawn(command, args, {
+    stdio: 'inherit',
+    env,
+    shell: false,
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+function main() {
+  try {
+    const { file, commandArgs, optional } = parseArgs(process.argv.slice(2));
+    const env = loadEnvFromFile(file, optional);
+    run(commandArgs, env);
+  } catch (error) {
+    console.error(`[ERROR] ${error instanceof Error ? error.message : 'Failed to run command with env file.'}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add scripts/run-with-env.mjs to load env vars from a specific file before running commands
- update deploy scripts:
  - dev/preview use .env.local
  - prod uses .env
- keep CI compatible via --optional fallback when env files are absent
- update DEPLOY/ENVIRONMENTS docs to reflect env loading rules

## Validation
- npm run lint
- npm run typecheck
