### PR TITLE
chore: rename .env to .env.production for clarity

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -129,7 +129,7 @@ npm run build:cf
 ```bash
 npm run deploy:cf:prod
 ```
-This command loads runtime vars from `.env` (local deploy path).
+This command loads runtime vars from `.env.production` (local deploy path).
 6. Set remaining env vars in Worker settings:
 - `DATABASE_URL`
 - `APP_BASE_URL`

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -27,9 +27,9 @@ npm run check:env:dev
 
 Local file rule:
 - Use `.env.local` for local development values.
-- Do not rely on `.env` for active local runtime configuration.
+- Do not rely on `.env.production` for active local runtime configuration.
 - Local dev deploy commands (`deploy:cf:dev`, `preview:cf`) load from `.env.local`.
-- Local prod deploy command (`deploy:cf:prod`) loads from `.env`.
+- Local prod deploy command (`deploy:cf:prod`) loads from `.env.production`.
 - In CI, these commands fall back to already-injected environment variables when env files are absent.
 
 ## 3. Required Variables

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preview:cf": "node scripts/run-with-env.mjs --file .env.local --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env.local --optional -- wrangler dev --env dev",
     "deploy:cf": "npm run deploy:cf:prod",
     "deploy:cf:dev": "node scripts/run-with-env.mjs --file .env.local --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env.local --optional -- wrangler deploy --env dev .open-next/worker.js",
-    "deploy:cf:prod": "node scripts/run-with-env.mjs --file .env --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env --optional -- wrangler deploy --env prod .open-next/worker.js"
+    "deploy:cf:prod": "node scripts/run-with-env.mjs --file .env.production --optional -- opennextjs-cloudflare build && node scripts/run-with-env.mjs --file .env.production --optional -- wrangler deploy --env prod .open-next/worker.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.987.0",


### PR DESCRIPTION
## Summary
- Rename `.env` to `.env.production` to distinguish it from `.env.local` (local dev)
- Update `deploy:cf:prod` script path accordingly
- Update references in `DEPLOY.md` and `ENVIRONMENTS.md`

## Test plan
- [ ] `npm run deploy:cf:prod` loads from `.env.production` locally
- [ ] CI prod deploy passes (CI uses GitHub Secrets, not local env files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)