### PR TITLE
fix: redirect unauthenticated users to /login instead of /_not-found

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,9 @@ export default async function middleware(request: NextRequest, event: NextFetchE
 
   const handler = clerkMiddleware(async (auth, req) => {
     if (!isPublicRoute(req)) {
-      await auth.protect();
+      await auth.protect({
+        unauthenticatedUrl: new URL('/login', req.url).toString(),
+      });
     }
   });
 


### PR DESCRIPTION
## Summary
- `auth.protect()` was silently rewriting unauthenticated requests to `/_not-found`, causing a \"Not Found\" page after Google OAuth sign-in
- Explicitly pass `unauthenticatedUrl: /login` so users are properly redirected to the login page

## Root Cause
Clerk's `auth.protect()` without `unauthenticatedUrl` defaults to a `/_not-found` rewrite instead of redirecting to the sign-in page when no session is present.

## Test plan
- [ ] Visiting `/practice` while signed out redirects to `/login`
- [ ] After Google OAuth sign-in, user lands on `/practice` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)