### PR TITLE
fix: redirect girapphe.com to www.girapphe.com in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,14 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default async function middleware(request: NextRequest, event: NextFetchEvent) {
+  // Redirect non-www to www in production
+  const host = request.headers.get('host') ?? '';
+  if (host === 'girapphe.com') {
+    const url = request.nextUrl.clone();
+    url.host = 'www.girapphe.com';
+    return NextResponse.redirect(url, 301);
+  }
+
   if (!hasValidClerkConfig()) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
- Clerk OAuth SSO callback URL was `girapphe.com/signup/sso-callback` (non-www) while the app serves on `www.girapphe.com`
- This caused the sso-callback route to return Not Found after Google sign-in
- Added 301 redirect from `girapphe.com` → `www.girapphe.com` in middleware so all traffic is consistently handled on the www subdomain

## Root Cause
Clerk constructs the OAuth callback URL based on the page the user was on. Since Cloudflare routes both `girapphe.com/*` and `www.girapphe.com/*` to the same Worker, users could land on either domain — but the app assumed `www`.

## Test plan
- [ ] Visiting `https://girapphe.com/signup` redirects to `https://www.girapphe.com/signup`
- [ ] Google OAuth sign-in completes successfully and lands on `/practice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)