### PR TITLE
perf: parallelize DB queries and deduplicate schema init

### DIFF
--- a/src/actions/card-actions.ts
+++ b/src/actions/card-actions.ts
@@ -40,6 +40,7 @@ type LeaderboardRow = {
 };
 
 let cardSchemaReady = false;
+let cardSchemaPromise: Promise<void> | null = null;
 
 const BASE_MOCK_CARDS: KnowledgeCard[] = [
   {
@@ -162,6 +163,12 @@ for (const edge of GRAPH_EDGES) {
 
 async function ensureCardSchema() {
   if (!process.env.DATABASE_URL || cardSchemaReady) return;
+  if (cardSchemaPromise) return cardSchemaPromise;
+  cardSchemaPromise = _initCardSchema();
+  return cardSchemaPromise;
+}
+
+async function _initCardSchema() {
 
   await pool.query(`
     CREATE TABLE IF NOT EXISTS knowledge_cards (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -72,8 +72,7 @@ export default async function DashboardPage() {
   const user = await getCurrentUser();
   if (!user) redirect('/login');
 
-  const stats = await getUserStats();
-  const domains = await getUserCardDomainProgress();
+  const [stats, domains] = await Promise.all([getUserStats(), getUserCardDomainProgress()]);
 
   const totalReviewed = stats.known + stats.saved + stats.unknown;
   const knownPercent = totalReviewed > 0 ? (stats.known / totalReviewed) * 100 : 0;

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -13,8 +13,7 @@ export default async function PracticePage() {
     redirect('/login');
   }
 
-  const initialCard = await getNextCard();
-  const stats = await getUserStats();
+  const [initialCard, stats] = await Promise.all([getNextCard(), getUserStats()]);
   const total = stats.known + stats.saved + stats.unknown;
   const knownPercent = total > 0 ? Math.round((stats.known / total) * 100) : 0;
 


### PR DESCRIPTION
## Summary
- `/practice` and `/dashboard` pages were awaiting DB queries sequentially, doubling latency on page load
- `ensureCardSchema()` could be called concurrently (e.g. from parallel `Promise.all`) causing redundant DB round-trips on the same cold Worker instance

## Changes
- Run `getNextCard` + `getUserStats` in parallel on `/practice`
- Run `getUserStats` + `getUserCardDomainProgress` in parallel on `/dashboard`
- Cache the in-flight `_initCardSchema()` promise so concurrent callers wait on the same initialization instead of each triggering their own

## Test plan
- [ ] `/practice` loads noticeably faster after sign-in
- [ ] `/dashboard` loads noticeably faster
- [ ] No errors from concurrent schema init

🤖 Generated with [Claude Code](https://claude.com/claude-code)