### PR TITLE
fix: auto-reload on ChunkLoadError after new deployment

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // ChunkLoadError occurs when a new deployment invalidates cached JS chunks.
+    // Automatically reload the page to fetch the latest assets.
+    if (error.name === 'ChunkLoadError' || error.message?.includes('Failed to load chunk')) {
+      window.location.reload();
+      return;
+    }
+    console.error(error);
+  }, [error]);
+
+  if (error.name === 'ChunkLoadError' || error.message?.includes('Failed to load chunk')) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <h2 className="text-2xl font-bold">Something went wrong</h2>
+      <button
+        onClick={reset}
+        className="rounded-md border px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- After a new deployment, browsers with cached pages may request stale JS chunks that no longer exist, causing `ChunkLoadError: Failed to load chunk`
- Added a global `error.tsx` boundary that detects `ChunkLoadError` and automatically calls `window.location.reload()` to fetch fresh assets

## Test plan
- [ ] Visiting the app immediately after a new deployment no longer shows the application error screen
- [ ] Other errors still show the generic error UI with a "Try again" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)