### PR TITLE
fix(learn-new): skip works through all unlearned cards without ending early

### DIFF
--- a/src/actions/card-actions.ts
+++ b/src/actions/card-actions.ts
@@ -458,7 +458,7 @@ function selectSmartSuggestedCard(cards: CardWithStatusRow[], mode: 'new' | 'rev
       randomTieBreaker: Math.random(),
     };
   }).filter((candidate) => {
-    if (mode === 'new') return candidate.card.status === null;
+    if (mode === 'new') return candidate.card.status !== 'known';
     return candidate.card.status === 'saved' || candidate.card.status === 'unknown';
   });
 

--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -71,10 +71,9 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       let next = await getNextCard(mode, [...skippedIds.current]);
 
       if (!next) {
-        // Every remaining unrated card has been skipped → cycle back
+        // Every remaining card has been skipped → full cycle reset, no exclusions
         skippedIds.current.clear();
-        skippedIds.current.add(card.id); // still avoid immediate re-show of this card
-        next = await getNextCard(mode, [card.id]);
+        next = await getNextCard(mode);
       }
 
       setCard(next);


### PR DESCRIPTION
## Summary
- **`selectSmartSuggestedCard`**: `mode='new'` 필터를 `status === null` → `status !== 'known'`으로 변경. 기존엔 null-status 카드만 Learn New에 표시돼서, 이전에 'Again'으로 표시한 카드(unknown status)가 Learn New에 아예 안 보였음. null-status 카드가 적은 사용자는 1~2장만 보이다가 스킵 즉시 종료됨
- **`handleSkip` cycle-back**: 모든 카드를 스킵했을 때 기존엔 방금 스킵한 카드를 제외하고 재시도 → 카드가 1장뿐이면 여전히 null → "All caught up". 이제 `skippedIds` 완전 초기화 후 exclusion 없이 재요청 → 카드가 1장만 남아도 순환

## Test plan
- [ ] Learn New에서 스킵을 반복해도 "All caught up"이 뜨지 않음
- [ ] 'Again'으로 표시한 카드가 Learn New에서 다시 나타남
- [ ] 모든 카드를 스킵하면 첫 카드부터 다시 순환됨
- [ ] Review Saved는 saved/unknown 카드만 표시 (기존 동작 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)