### PR TITLE
fix: bug sweep — save reliability + skippedIds restore

### DIFF
--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -29,6 +29,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
     setLoading(true);
     setError(null);
     setHistory(prev => [...prev, card]);
+    const wasSkipped = skippedIds.current.has(card.id);
     skippedIds.current.delete(card.id); // rated → no longer needs cycling back
 
     try {
@@ -36,6 +37,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       if (!saveResult.success) {
         setError('Could not save. Please try again.');
         setHistory(prev => prev.slice(0, -1));
+        if (wasSkipped) skippedIds.current.add(card.id); // restore skip state
         return;
       }
       // No exclusions: server scoring naturally deprioritises rated cards; retry once on transient failure
@@ -50,6 +52,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       console.error('handleAction failed:', e);
       setError('Something went wrong.');
       setHistory(prev => prev.slice(0, -1));
+      if (wasSkipped) skippedIds.current.add(card.id); // restore skip state
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
코드 감사(audit)에서 발견한 실제 버그 2개 수정

### 1. `saveCardState`: knowledge graph sync 실패가 카드 저장 전체를 막는 버그
- **기존**: `user_card_states` INSERT(카드 상태 저장)와 `user_knowledge_states` INSERT(지식 그래프 동기화)가 같은 try-catch 안에 있었음
- **문제**: `graph_nodes` 테이블이 없거나 두 번째 쿼리가 실패하면 카드 상태가 정상 저장됐음에도 `{ success: false }` 반환 → "Could not save. Please try again." 에러 표시
- **수정**: 두 번째 INSERT를 별도 try-catch로 분리. 실패 시 `console.warn`만 출력, 카드 저장 성공에 영향 없음

### 2. `handleAction`: save 실패 시 `skippedIds` 복원 안 되는 버그
- **기존**: `skippedIds.current.delete(card.id)`가 save 시도 전에 호출됨. save가 실패(`!success` 또는 exception)해도 카드가 skip 목록에서 영구 제거됨
- **수정**: `wasSkipped` 플래그 저장 후 양쪽 실패 경로에서 복원

## Test plan
- [ ] Known/Save/Again 버튼이 정상 저장 후 다음 카드로 이동하는지 확인
- [ ] 저장 실패 시 에러 메시지가 표시되고 같은 카드가 유지되는지 확인
- [ ] 저장 실패 후 skip 동작이 정상적으로 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)