### PR TITLE
fix: show main content in knowledge graph details

### DIFF
--- a/src/components/knowledge-graph-3d.tsx
+++ b/src/components/knowledge-graph-3d.tsx
@@ -17,6 +17,7 @@ type SelectedNode = {
   id: string;
   name: string;
   desc?: string;
+  mainContent?: string;
   domain?: string;
   level?: string;
   status?: CardStatus | null;
@@ -94,6 +95,7 @@ export default function KnowledgeGraph3D({ cards, onClose }: Props) {
         color: statusColor,
         group: 'card',
         desc: card.summary,
+        mainContent: card.explanation,
         domain: card.domain,
         level: card.level,
         status: card.status,
@@ -311,6 +313,17 @@ export default function KnowledgeGraph3D({ cards, onClose }: Props) {
               <p className="text-sm text-gray-300 mb-6 leading-relaxed">
                 {selectedNode.desc}
               </p>
+            )}
+
+            {selectedNode.mainContent && (
+              <div className="mb-6">
+                <p className="text-[10px] uppercase tracking-widest text-gray-500 mb-2 font-semibold">
+                  Main Content
+                </p>
+                <p className="whitespace-pre-line text-sm text-gray-300 leading-relaxed">
+                  {selectedNode.mainContent}
+                </p>
+              </div>
             )}
 
             {/* Related concepts */}

--- a/src/data/card-content.ts
+++ b/src/data/card-content.ts
@@ -157,7 +157,7 @@ export const CARD_CONTENT: Record<string, { summary: string; explanation: string
   },
   duality: {
     summary: 'Primal (min f) ↔ Dual (max g), where g(λ) = min_x L(x,λ); dual provides lower bound',
-    explanation: 'Weak duality: d* ≤ p*. Strong duality (Slater's condition): d* = p*.\nDual variables = shadow prices of constraints.\nSVM dual: often easier to solve; kernelizes naturally.',
+    explanation: 'Weak duality: d* ≤ p*. Strong duality (Slater\'s condition): d* = p*.\nDual variables = shadow prices of constraints.\nSVM dual: often easier to solve; kernelizes naturally.',
   },
   stochastic_gradient_descent: {
     summary: 'Gradient estimated from a random mini-batch: θ ← θ − α∇L_{batch}(θ)',


### PR DESCRIPTION
## Summary
- show each concept's main content (explanation) in the Knowledge Graph detail panel
- keep summary + related concepts behavior unchanged
- fix a string escape typo in card content that could break TypeScript parsing

## Validation
- npm run typecheck
- npm run check