### PR TITLE
fix: prevent server re-renders from resetting CardViewer mid-session

### DIFF
--- a/src/actions/card-actions.ts
+++ b/src/actions/card-actions.ts
@@ -8,6 +8,12 @@ import { GRAPH_NODES } from '@/data/graph-nodes';
 import { CARD_CONTENT } from '@/data/card-content';
 import { getCardLevelMeta, type CardLevel } from '@/lib/card-level';
 
+export type PrerequisiteInfo = {
+  id: string;
+  label: string;
+  status: CardStatus | null;
+};
+
 export type KnowledgeCard = {
   id: string;
   title: string;
@@ -18,6 +24,7 @@ export type KnowledgeCard = {
   level: CardLevel;
   related_concepts?: string[];
   suggest_reason?: string;
+  prerequisites?: PrerequisiteInfo[];
 };
 
 export type CardStatus = 'known' | 'saved';
@@ -576,7 +583,18 @@ function selectSmartSuggestedCard(cards: CardWithStatusRow[], mode: 'new' | 'rev
     return a.randomTieBreaker - b.randomTieBreaker;
   });
 
-  return candidates[0]?.card ?? null;
+  const selected = candidates[0]?.card;
+  if (!selected) return null;
+
+  const normalizedId = normalizeGraphNodeId(selected.id);
+  const prereqNodeIds = (PREREQ_INCOMING.get(normalizedId) ?? []).slice(0, 3);
+  const prerequisites: PrerequisiteInfo[] = prereqNodeIds.map((prereqId) => {
+    const label = NODE_BY_ID.get(prereqId)?.label ?? prereqId.replace(/_/g, ' ');
+    const status = nodeStatusById.get(prereqId) ?? null;
+    return { id: prereqId, label, status };
+  });
+
+  return { ...selected, prerequisites: prerequisites.length > 0 ? prerequisites : undefined };
 }
 
 export async function saveCardState(cardId: string, status: CardStatus) {

--- a/src/actions/card-actions.ts
+++ b/src/actions/card-actions.ts
@@ -653,7 +653,8 @@ export async function saveCardState(cardId: string, status: CardStatus) {
       console.warn('Knowledge graph sync skipped:', knowledgeErr);
     }
 
-    revalidatePath('/practice');
+    // Do NOT revalidate '/practice' — the practice session is fully client-managed.
+    // Revalidating triggers a server re-render that overwrites CardViewer state mid-session.
     revalidatePath('/saved');
     revalidatePath('/knowledge');
     revalidatePath('/dashboard');

--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
-import { KnowledgeCard, saveCardState, getNextCard, CardStatus, getUserStats } from '@/actions/card-actions';
+import { KnowledgeCard, saveCardState, getNextCard, CardStatus, getUserStats, PrerequisiteInfo } from '@/actions/card-actions';
 import Card from './card';
 import Link from 'next/link';
 
@@ -206,6 +206,12 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
         setRevealed(true);
         return;
       }
+      // Z for undo — works regardless of reveal state
+      if ((event.key === 'z' || event.key === 'Z') && undoVisible && !loading) {
+        event.preventDefault();
+        handleUndo();
+        return;
+      }
       if (!revealed) return; // block rating keys until answer is shown
       if (event.key === '1') void handleAction('known');
       if (event.key === '2') void handleAction('saved');
@@ -214,7 +220,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [loading, card, revealed, handleAction, handleSkip, handlePrevious]);
+  }, [loading, card, revealed, undoVisible, handleAction, handleSkip, handlePrevious, handleUndo]);
 
   // ── All done ─────────────────────────────────────────────────
   if (!card) {
@@ -341,6 +347,35 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       {/* Card — explanation hidden until revealed */}
       <Card key={card.id} card={card} interactiveQuizMode={false} revealed={revealed} />
 
+      {/* Prerequisites strip */}
+      {card.prerequisites && card.prerequisites.length > 0 && (
+        <div className="mt-2 px-3 py-2.5 bg-white border border-gray-100 rounded-xl shadow-sm">
+          <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+            Prerequisites
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {card.prerequisites.map((prereq: PrerequisiteInfo) => (
+              <span
+                key={prereq.id}
+                title={prereq.status === 'known' ? 'Known' : prereq.status === 'saved' ? 'In learning queue' : 'Not yet learned'}
+                className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium border ${
+                  prereq.status === 'known'
+                    ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                    : prereq.status === 'saved'
+                    ? 'bg-amber-50 text-amber-700 border-amber-200'
+                    : 'bg-gray-50 text-gray-500 border-gray-200'
+                }`}
+              >
+                <span aria-hidden="true">
+                  {prereq.status === 'known' ? '✓' : prereq.status === 'saved' ? '🔖' : '○'}
+                </span>
+                {prereq.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Error / loading feedback */}
       <div aria-live="polite" aria-atomic="true" className="mt-2 min-h-[1rem] text-center">
         {error && <p className="text-xs text-red-500">{error}</p>}
@@ -412,7 +447,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       <p className="mt-1 text-xs text-gray-300 text-center hidden sm:block">
         {!revealed
           ? <><kbd className="font-mono">Space</kbd> or <kbd className="font-mono">Enter</kbd> to reveal · <kbd className="font-mono">→</kbd> skip</>
-          : <><kbd className="font-mono">1</kbd> known · <kbd className="font-mono">2</kbd> study · <kbd className="font-mono">←</kbd> back · <kbd className="font-mono">→</kbd> skip</>
+          : <><kbd className="font-mono">1</kbd> known · <kbd className="font-mono">2</kbd> study · {undoVisible && <><kbd className="font-mono">Z</kbd> undo · </>}<kbd className="font-mono">←</kbd> back · <kbd className="font-mono">→</kbd> skip</>
         }
       </p>
     </div>

--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -40,7 +40,13 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
   const [reviewRoundCompleted, setReviewRoundCompleted] = useState(false);
   const [backNavigatedCardId, setBackNavigatedCardId] = useState<string | null>(null);
 
-  // Mode switch must reset local session state so new/review queues don't bleed into each other.
+  // Reset session state on mount only.
+  // key={mode} on CardViewer (in practice/page.tsx) causes a full unmount+remount on mode
+  // switch, so this effect correctly fires on initial load AND mode changes.
+  // We intentionally do NOT include initialCard/initialStats in deps: Next.js re-renders
+  // server components after every server action, which would update these props and
+  // re-trigger this effect mid-session — resetting the card and wiping ratedIds/history.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setCard(initialCard);
     setHistory([]);
@@ -57,7 +63,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
     setReviewedThisRound(0);
     setReviewRoundCompleted(false);
     setBackNavigatedCardId(null);
-  }, [mode, initialCard, initialStats]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const reviewedCount = useMemo(() => {
     const reviewed = history

--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -311,9 +311,12 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
               />
             </div>
             {reviewRoundCompleted && (
-              <p className="mt-2 text-xs font-medium text-emerald-600" aria-live="polite">
-                This review round is complete. You reviewed every learning-queue card once.
-              </p>
+              <div className="mt-2 flex items-center gap-2 rounded-lg bg-emerald-50 border border-emerald-200 px-3 py-2" role="status" aria-live="polite">
+                <span className="text-base" aria-hidden="true">🎉</span>
+                <p className="text-xs font-semibold text-emerald-700">
+                  Round complete! You reviewed all {reviewPool} card{reviewPool !== 1 ? 's' : ''} — starting next round.
+                </p>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
## Root cause

Next.js re-renders server components after **every** server action completes (including `saveCardState`). This updated `initialCard`/`initialStats` props on `CardViewer`, which triggered the `useEffect([mode, initialCard, initialStats])` — resetting `ratedIds`, `history`, and `card` back to the server's initial state mid-session.

Removing `revalidatePath('/practice')` (previous commit) was not sufficient because Next.js re-renders unconditionally on server action completion.

## Fix

Changed `useEffect` deps from `[mode, initialCard, initialStats]` → `[]`.

`key={mode}` on `CardViewer` in `practice/page.tsx` already causes a full unmount+remount when mode changes, so empty-deps correctly fires on:
- ✅ Initial page load
- ✅ Mode switch (Learn New ↔ Review)
- ❌ Server re-renders mid-session (no longer fires)

## Issues fixed

1. **Study/Known button not navigating** — server re-render was overwriting the client's `setCard(next)` with the initial card, making it look like nothing happened
2. **Review round-complete banner not appearing** — `reviewRoundCompleted` was being reset to `false` by the re-render before the user could see the 🎉 banner

## Test plan

- [ ] Click Study multiple times in Learn New — card advances each time
- [ ] Click Known multiple times in Learn New — card advances each time  
- [ ] In Review mode, go through all cards — 🎉 "Round complete!" banner appears, then next round starts
- [ ] Switch between Learn New ↔ Review — state resets correctly each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)