### PR TITLE
refactor(cards): remove mock cards, quiz UI, and broken filters

### DIFF
--- a/src/actions/card-actions.ts
+++ b/src/actions/card-actions.ts
@@ -23,7 +23,6 @@ export type KnowledgeCard = {
   domain: string;
   level: CardLevel;
   related_concepts?: string[];
-  suggest_reason?: string;
   prerequisites?: PrerequisiteInfo[];
 };
 
@@ -84,53 +83,6 @@ function getKnowledgeCardLimit(): number {
 const KNOWLEDGE_CARD_LIMIT = getKnowledgeCardLimit();
 
 const DRILL_GENERATION_BATCH = 250;
-
-const BASE_MOCK_CARDS: KnowledgeCard[] = [
-  {
-    id: 'burg_method',
-    title: 'Burg Method',
-    summary: 'MaxEnt Spectral Estimation',
-    explanation:
-      'Minimizes forward & backward prediction errors.\n\nKey Benefit:\nHigh resolution for short data records (unlike FFT).\n\nConstraint:\nAlways guarantees a stable filter.',
-    wiki_url: 'https://en.wikipedia.org/wiki/Burg_method',
-    domain: 'signal',
-    level: 'understand',
-    related_concepts: ['Autoregressive Model', 'Spectral Density', 'Levinson Recursion'],
-  },
-  {
-    id: 'kalman_filter',
-    title: 'Kalman Filter',
-    summary: 'Optimal Recursive Linear Estimator',
-    explanation:
-      '$$x_k = A\\,x_{k-1} + B\\,u_k + w_k$$\n$$z_k = H\\,x_k + v_k$$\n\n1. Predict:\n$$\\hat{x}_k = A\\,\\hat{x}_{k-1} + B\\,u_k$$\n$$P_k = A\\,P_{k-1}\\,A^T + Q$$\n\n2. Update:\n$$K_k = P_k H^T\\!(H P_k H^T + R)^{-1}$$\n$$\\hat{x}_k^{\\,+} = \\hat{x}_k + K_k(z_k - H\\,\\hat{x}_k)$$',
-    wiki_url: 'https://en.wikipedia.org/wiki/Kalman_filter',
-    domain: 'control',
-    level: 'apply',
-    related_concepts: ['Bayesian Inference', 'Hidden Markov Model', 'Control Theory'],
-  },
-  {
-    id: 'nyquist_shannon',
-    title: 'Nyquist-Shannon Theorem',
-    summary: 'Sampling Rate Requirement',
-    explanation:
-      '$$f_s > 2 \\cdot f_{\\max}$$\n\nIf $f_s < 2\\,f_{\\max}$:\nAliasing occurs (high freq appears as low freq).\n\nNyquist Frequency $= f_s \\,/\\, 2$',
-    wiki_url: 'https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem',
-    domain: 'signal',
-    level: 'memorize',
-    related_concepts: ['Aliasing', 'Fourier Transform', 'Quantization'],
-  },
-  {
-    id: 'transformer_model',
-    title: 'Transformer Architecture',
-    summary: 'Attention-based Sequence Model',
-    explanation:
-      '$$\\text{Attention}(Q, K, V) = \\text{softmax}\\!\\left(\\frac{QK^T}{\\sqrt{d_k}}\\right)V$$\n\nKey Innovation:\nReplaces recurrence with Self-Attention, allowing massive parallelization.\n\nKey Components:\n- Multi-Head Attention\n- Positional Encoding\n- Feed-Forward Networks',
-    wiki_url: 'https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)',
-    domain: 'ml',
-    level: 'understand',
-    related_concepts: ['Self-Attention', 'Positional Encoding', 'BERT', 'GPT'],
-  },
-];
 
 const EDGE_MAP = GRAPH_EDGES.reduce<Record<string, string[]>>((acc, edge) => {
   if (!acc[edge.source]) acc[edge.source] = [];
@@ -202,10 +154,7 @@ const CORE_GRAPH_CARDS: KnowledgeCard[] = GRAPH_NODES
     };
   });
 
-const CORE_CARDS: KnowledgeCard[] = [
-  ...BASE_MOCK_CARDS,
-  ...CORE_GRAPH_CARDS.filter((generated) => !BASE_MOCK_CARDS.some((base) => base.id === generated.id)),
-];
+const CORE_CARDS: KnowledgeCard[] = CORE_GRAPH_CARDS;
 
 const DRILL_CARD_COUNT = Math.max(0, TARGET_CARD_COUNT - CORE_CARDS.length);
 const DRILL_ELIGIBLE_NODES = [...GRAPH_NODES]
@@ -783,15 +732,8 @@ function selectSmartSuggestedCard(cards: CardWithStatusRow[], mode: 'new' | 'rev
 
     const lastSeenTs = card.last_seen ? new Date(card.last_seen).getTime() : 0;
 
-    let suggest_reason = '';
-    if (cardStatus === 'saved') {
-      suggest_reason = `Memorize-first review · Difficulty ${levelMeta.rank} (${levelMeta.label})`;
-    } else if (cardStatus !== 'known') {
-      suggest_reason = `Memorize-first queue · Difficulty ${levelMeta.rank} (${levelMeta.label})`;
-    }
-
     return {
-      card: { ...card, suggest_reason },
+      card,
       score,
       lastSeenTs,
       randomTieBreaker: Math.random(),

--- a/src/components/card-viewer.tsx
+++ b/src/components/card-viewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
-import { KnowledgeCard, saveCardState, getNextCard, CardStatus, getUserStats, PrerequisiteInfo } from '@/actions/card-actions';
+import { KnowledgeCard, saveCardState, getNextCard, CardStatus, getUserStats, type PrerequisiteInfo } from '@/actions/card-actions';
 import Card from './card';
 import Link from 'next/link';
 
@@ -354,7 +354,7 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
       )}
 
       {/* Card — explanation hidden until revealed */}
-      <Card key={card.id} card={card} interactiveQuizMode={false} revealed={revealed} />
+      <Card key={card.id} card={card} revealed={revealed} />
 
       {/* Prerequisites strip */}
       {card.prerequisites && card.prerequisites.length > 0 && (

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { KnowledgeCard, NodeQuiz, generateQuizForNode } from '@/actions/card-actions';
+import { KnowledgeCard } from '@/actions/card-actions';
 import { getCardLevelMeta } from '@/lib/card-level';
 import MathText from './math-text';
 
 interface CardProps {
   card: KnowledgeCard;
-  interactiveQuizMode?: boolean;
   /** When false, hides the explanation (used for card-flip / self-test UX). Defaults to true. */
   revealed?: boolean;
 }
@@ -20,31 +18,9 @@ const DOMAIN_COLORS: Record<string, string> = {
   other: 'bg-gray-100 text-gray-700 border-gray-200',
 };
 
-export default function Card({ card, interactiveQuizMode = true, revealed = true }: CardProps) {
+export default function Card({ card, revealed = true }: CardProps) {
   const domainStyle = DOMAIN_COLORS[card.domain] ?? DOMAIN_COLORS.other;
   const levelMeta = getCardLevelMeta(card.level);
-  const [quiz, setQuiz] = useState<NodeQuiz | null>(null);
-  const [quizLoading, setQuizLoading] = useState(interactiveQuizMode);
-  const [quizError, setQuizError] = useState<string | null>(null);
-  const [selectedAnswerIndex, setSelectedAnswerIndex] = useState<number | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    if (!interactiveQuizMode) return () => { active = false; };
-
-    generateQuizForNode(card.id)
-      .then((nextQuiz) => { if (active) setQuiz(nextQuiz); })
-      .catch(() => { if (active) setQuizError('Quiz unavailable for this concept.'); })
-      .finally(() => { if (active) setQuizLoading(false); });
-
-    return () => { active = false; };
-  }, [card.id, interactiveQuizMode]);
-
-  const showExplanation = revealed && (!interactiveQuizMode || !quiz || selectedAnswerIndex !== null);
-  const isAnswerCorrect = useMemo(() => {
-    if (!quiz || selectedAnswerIndex === null) return null;
-    return selectedAnswerIndex === quiz.correctAnswerIndex;
-  }, [quiz, selectedAnswerIndex]);
 
   return (
     <article
@@ -64,80 +40,11 @@ export default function Card({ card, interactiveQuizMode = true, revealed = true
         {card.title}
       </h2>
 
-      {card.suggest_reason && (
-        <div
-          aria-label={`Suggested because: ${card.suggest_reason}`}
-          className="text-[10px] font-bold text-blue-600 uppercase tracking-tight bg-blue-50 border border-blue-100 px-2 py-0.5 rounded w-fit"
-        >
-          ✨ {card.suggest_reason}
-        </div>
-      )}
-
       <p className="text-gray-600 leading-relaxed flex-grow">
         {card.summary}
       </p>
 
-      {interactiveQuizMode && (
-        <section aria-label="Quick quiz" className="rounded-lg border border-blue-100 bg-blue-50/70 p-4">
-          <h3 className="text-xs font-bold uppercase tracking-widest text-blue-700">
-            Quick Quiz
-          </h3>
-
-          {quizLoading ? (
-            <p className="mt-2 text-sm text-blue-800/80 animate-pulse">Generating question…</p>
-          ) : quizError ? (
-            <p className="mt-2 text-sm text-gray-500">{quizError}</p>
-          ) : quiz ? (
-            <div className="mt-3 space-y-2">
-              <p className="text-sm font-medium text-slate-800">{quiz.question}</p>
-              <div className="grid gap-2" role="group" aria-label="Answer choices">
-                {quiz.choices.map((choice, index) => {
-                  const isSelected = selectedAnswerIndex === index;
-                  const isCorrectChoice = quiz.correctAnswerIndex === index;
-                  const answered = selectedAnswerIndex !== null;
-
-                  let choiceStyle = 'border-slate-200 hover:border-blue-300 hover:bg-blue-50';
-                  if (answered) {
-                    if (isCorrectChoice) choiceStyle = 'border-emerald-400 bg-emerald-50 text-emerald-900 font-medium';
-                    else if (isSelected) choiceStyle = 'border-red-300 bg-red-50 text-red-800';
-                    else choiceStyle = 'border-slate-200 opacity-60';
-                  }
-
-                  return (
-                    <button
-                      key={`${card.id}-choice-${index}`}
-                      type="button"
-                      disabled={answered}
-                      onClick={() => setSelectedAnswerIndex(index)}
-                      aria-pressed={isSelected}
-                      aria-describedby={answered ? `quiz-feedback-${card.id}` : undefined}
-                      className={`w-full rounded-md border px-3 py-2 text-left text-sm transition ${choiceStyle} disabled:cursor-default`}
-                    >
-                      <span className="mr-2 font-semibold text-gray-500">{String.fromCharCode(65 + index)}.</span>
-                      {choice}
-                      {answered && isCorrectChoice && <span className="ml-2" aria-hidden="true">✓</span>}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
-
-          {isAnswerCorrect !== null ? (
-            <p
-              id={`quiz-feedback-${card.id}`}
-              role="status"
-              className={`mt-3 text-xs font-medium ${isAnswerCorrect ? 'text-emerald-700' : 'text-red-700'}`}
-            >
-              {isAnswerCorrect
-                ? '✓ Correct! See explanation below.'
-                : '✗ Not quite. Check the explanation below.'}
-            </p>
-          ) : null}
-        </section>
-      )}
-
-      {card.explanation && showExplanation && (
+      {card.explanation && revealed && (
         <section aria-label="Key facts and formulas" className="bg-amber-50 border border-amber-100 p-4 rounded-lg text-sm text-gray-800 overflow-y-auto max-h-48 custom-scrollbar">
            <h3 className="text-xs font-bold text-amber-800 uppercase tracking-widest mb-2">
              💡 Key Facts & Formulas

--- a/src/components/knowledge-map.tsx
+++ b/src/components/knowledge-map.tsx
@@ -142,7 +142,6 @@ export default function KnowledgeMap({ initialCards }: Props) {
                 <option value="all">All Status</option>
                 <option value="known">Known</option>
                 <option value="saved">Saved</option>
-                <option value="unknown">Unknown</option>
                 <option value="unstarted">Not Started</option>
               </select>
               


### PR DESCRIPTION
- Remove BASE_MOCK_CARDS (4 hardcoded dev-era cards) that created
  duplicate entries alongside graph-generated cards due to mismatched
  ID prefixes (e.g. kalman_filter vs graph_kalman_filter)
- Remove interactiveQuizMode and Quick Quiz section from Card component
  (dead code: always called with false; conflicts with memorize-first UX)
- Remove suggest_reason field and badge (internal scoring detail
  exposed to users; not suitable as user-facing text)
- Remove broken "Unknown" status filter option in KnowledgeMap
  (CardStatus is only 'known'|'saved'; null is covered by "Not Started")

https://claude.ai/code/session_01KmpYBbC3yNi4WsCZ81GYxr