### PR TITLE
feat(admin): add graph admin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This project implements an AI/CS knowledge graph MVP with:
 - Data model: `docs/reference/data-model.md`
 - Knowledge graph spec: `docs/reference/knowledge-graph-spec.md`
 - Development/operations: `docs/operations/development.md`
+- Admin operations: `docs/operations/admin.md`
 
 ## Key Implementation Files
 
@@ -85,6 +86,7 @@ Core routes:
 - `/my-knowledge`
 - `/dashboard`
 - `/ranking`
+- `/admin` (admin-only, PostgreSQL required)
 
 Quality commands:
 
@@ -125,8 +127,8 @@ Authentication is powered by [Clerk](https://clerk.com). Configure these environ
 Use environment-specific templates:
 
 ```bash
-cp .env.dev.example .env.local
-# For production values/secrets, use .env.prod.example as the reference.
+cp apps/web/.env.dev.example apps/web/.env.local
+# For production values/secrets, use apps/web/.env.prod.example as the reference.
 ```
 
 ```
@@ -140,6 +142,15 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/practice
 ```
 
 Get your keys from the [Clerk dashboard](https://dashboard.clerk.com).
+
+Admin routes additionally require:
+
+```bash
+ADMIN_CLERK_USER_ID=user_...
+```
+
+`ADMIN_CLERK_USER_ID` must match the Clerk user id allowed to access `/admin`. Admin pages
+also require `DATABASE_URL`; they do not use the app's in-memory fallback mode.
 
 Clerk handles:
 - Email/password sign-up and sign-in (with built-in email verification)

--- a/apps/web/.env.dev.example
+++ b/apps/web/.env.dev.example
@@ -26,6 +26,9 @@ KNOWLEDGE_CARD_LIMIT=600
 # Default 1000. Increase if you add more content sources.
 CARD_POOL_SIZE=1000
 
+# Admin routes (required only for /admin access)
+ADMIN_CLERK_USER_ID=user_...
+
 # Cloudflare deploy credentials (optional for local-only dev)
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ACCOUNT_ID=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -18,6 +18,9 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/practice
 # Database (optional in local dev; required in production)
 DATABASE_URL=postgres://user:password@host/dev_db?sslmode=require
 
+# Admin routes (required only for /admin access)
+ADMIN_CLERK_USER_ID=user_...
+
 # Cloudflare deployment credentials
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ACCOUNT_ID=

--- a/apps/web/.env.prod.example
+++ b/apps/web/.env.prod.example
@@ -17,6 +17,9 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/practice
 # Database (required in prod)
 DATABASE_URL=postgres://user:password@host/prod_db?sslmode=require
 
+# Admin routes (set to the Clerk user id allowed to access /admin)
+ADMIN_CLERK_USER_ID=user_...
+
 # Cloudflare deploy credentials (required for CI/CD deploy)
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ACCOUNT_ID=

--- a/apps/web/src/actions/admin-actions.ts
+++ b/apps/web/src/actions/admin-actions.ts
@@ -1,0 +1,163 @@
+'use server';
+
+import pool from '@/lib/db';
+import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/auth';
+import { ADMIN_DOMAINS, ADMIN_EDGE_TYPES, ADMIN_NODE_TYPES } from '@/lib/admin-config';
+
+function ensureAdminDatabase() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('Admin database access requires DATABASE_URL to be configured.');
+  }
+}
+
+function normalizeRequiredText(value: string, field: string, maxLength: number) {
+  const normalized = value.trim().slice(0, maxLength);
+  if (!normalized) throw new Error(`${field} is required`);
+  return normalized;
+}
+
+function parseBoundedNumber(value: number, field: string, min: number, max: number) {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${field} must be between ${min} and ${max}`);
+  }
+  return value;
+}
+
+function ensureAllowedValue<T extends readonly string[]>(value: string, allowed: T, field: string) {
+  if (!allowed.includes(value)) {
+    throw new Error(`${field} is invalid`);
+  }
+  return value;
+}
+
+export type AdminNode = {
+  id: string;
+  label: string;
+  domain: string;
+  level: number;
+  difficulty: number;
+  type: string;
+  created_at: string;
+};
+
+export type AdminEdge = {
+  id: number;
+  source: string;
+  target: string;
+  type: string;
+  weight: number;
+};
+
+export type AdminUser = {
+  user_id: string;
+  known: number;
+  partial: number;
+  total: number;
+  last_updated: string | null;
+};
+
+export async function getAdminNodes(): Promise<AdminNode[]> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  const { rows } = await pool.query<AdminNode>(
+    'SELECT id, label, domain, level, difficulty, type, created_at FROM graph_nodes ORDER BY domain, level, label'
+  );
+  return rows;
+}
+
+export async function createAdminNode(data: {
+  id: string;
+  label: string;
+  domain: string;
+  level: number;
+  difficulty: number;
+  type: string;
+}): Promise<void> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+
+  const id = normalizeRequiredText(data.id, 'id', 100).toLowerCase().replace(/\s+/g, '_');
+  const label = normalizeRequiredText(data.label, 'label', 200);
+  const domain = ensureAllowedValue(normalizeRequiredText(data.domain, 'domain', 50), ADMIN_DOMAINS, 'domain');
+  const type = ensureAllowedValue(normalizeRequiredText(data.type, 'type', 50), ADMIN_NODE_TYPES, 'type');
+  const level = parseBoundedNumber(data.level, 'level', 0, 5);
+  const difficulty = parseBoundedNumber(data.difficulty, 'difficulty', 1, 5);
+
+  await pool.query(
+    `INSERT INTO graph_nodes (id, label, domain, level, difficulty, type)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, label, domain, level, difficulty, type]
+  );
+  revalidatePath('/admin');
+  revalidatePath('/admin/nodes');
+}
+
+export async function deleteAdminNode(id: string): Promise<void> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  await pool.query('DELETE FROM graph_nodes WHERE id = $1', [normalizeRequiredText(id, 'id', 100)]);
+  revalidatePath('/admin');
+  revalidatePath('/admin/nodes');
+  revalidatePath('/admin/edges');
+}
+
+export async function getAdminEdges(): Promise<AdminEdge[]> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  const { rows } = await pool.query<AdminEdge>(
+    'SELECT id, source, target, type, weight FROM graph_edges ORDER BY source, target'
+  );
+  return rows;
+}
+
+export async function createAdminEdge(data: {
+  source: string;
+  target: string;
+  type: string;
+  weight: number;
+}): Promise<void> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  const source = normalizeRequiredText(data.source, 'source', 100);
+  const target = normalizeRequiredText(data.target, 'target', 100);
+  const type = ensureAllowedValue(normalizeRequiredText(data.type, 'type', 50), ADMIN_EDGE_TYPES, 'type');
+  const weight = parseBoundedNumber(data.weight, 'weight', 0, 1);
+
+  if (source === target) {
+    throw new Error('source and target must be different nodes');
+  }
+
+  await pool.query(
+    'INSERT INTO graph_edges (source, target, type, weight) VALUES ($1, $2, $3, $4)',
+    [source, target, type, weight]
+  );
+  revalidatePath('/admin');
+  revalidatePath('/admin/edges');
+}
+
+export async function deleteAdminEdge(id: number): Promise<void> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  if (!Number.isInteger(id) || id < 1) throw new Error('id is invalid');
+  await pool.query('DELETE FROM graph_edges WHERE id = $1', [id]);
+  revalidatePath('/admin');
+  revalidatePath('/admin/edges');
+}
+
+export async function getAdminUsers(): Promise<AdminUser[]> {
+  await requireAdminUser();
+  ensureAdminDatabase();
+  const { rows } = await pool.query<AdminUser>(
+    `SELECT
+       user_id,
+       COUNT(*)::int                                       AS total,
+       COUNT(*) FILTER (WHERE knowledge_state = 1)::int   AS known,
+       COUNT(*) FILTER (WHERE knowledge_state = 0.5)::int AS partial,
+       MAX(last_updated)                                   AS last_updated
+     FROM user_knowledge_states
+     GROUP BY user_id
+     ORDER BY MAX(last_updated) DESC NULLS LAST`
+  );
+  return rows;
+}

--- a/apps/web/src/app/admin/edges/page.tsx
+++ b/apps/web/src/app/admin/edges/page.tsx
@@ -1,0 +1,142 @@
+import {
+  createAdminEdge,
+  deleteAdminEdge,
+  getAdminEdges,
+  getAdminNodes,
+} from '@/actions/admin-actions';
+import { ADMIN_EDGE_TYPES } from '@/lib/admin-config';
+
+export const dynamic = 'force-dynamic';
+
+const inputCls =
+  'w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-gray-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60';
+
+export default async function AdminEdgesPage() {
+  const databaseConfigured = Boolean(process.env.DATABASE_URL);
+  const [edges, nodes] = databaseConfigured
+    ? await Promise.all([getAdminEdges(), getAdminNodes()])
+    : [[], []];
+  const nodeMap = new Map(nodes.map((node) => [node.id, node.label]));
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="mb-1 text-xl font-semibold">Graph Edges</h1>
+        <p className="text-sm text-gray-400">{edges.length} edges total</p>
+      </div>
+
+      {!databaseConfigured && (
+        <div className="rounded-xl border border-amber-700/40 bg-amber-950/40 p-4 text-sm text-amber-200">
+          Set `DATABASE_URL` before using admin edge management. This screen works only against the
+          PostgreSQL-backed graph tables.
+        </div>
+      )}
+
+      <form
+        action={async (formData: FormData) => {
+          'use server';
+          await createAdminEdge({
+            source: formData.get('source') as string,
+            target: formData.get('target') as string,
+            type: formData.get('type') as string,
+            weight: Number(formData.get('weight')),
+          });
+        }}
+        className="grid grid-cols-2 gap-3 rounded-xl border border-gray-800 p-4 md:grid-cols-4"
+      >
+        <h2 className="col-span-full text-sm font-medium text-gray-300">Add Edge</h2>
+        <select name="source" required disabled={!databaseConfigured} className={inputCls}>
+          <option value="">source node…</option>
+          {nodes.map((node) => (
+            <option key={node.id} value={node.id}>
+              {node.label}
+            </option>
+          ))}
+        </select>
+        <select name="target" required disabled={!databaseConfigured} className={inputCls}>
+          <option value="">target node…</option>
+          {nodes.map((node) => (
+            <option key={node.id} value={node.id}>
+              {node.label}
+            </option>
+          ))}
+        </select>
+        <select name="type" required disabled={!databaseConfigured} className={inputCls}>
+          {ADMIN_EDGE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+        <input
+          name="weight"
+          type="number"
+          step="0.1"
+          placeholder="weight"
+          defaultValue="1"
+          min="0"
+          max="1"
+          required
+          disabled={!databaseConfigured}
+          className={inputCls}
+        />
+        <button
+          type="submit"
+          disabled={!databaseConfigured}
+          className="col-span-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-950 disabled:text-indigo-300"
+        >
+          Add Edge
+        </button>
+      </form>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-800 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th className="pb-2 pr-4">ID</th>
+              <th className="pb-2 pr-4">Source</th>
+              <th className="pb-2 pr-4">Target</th>
+              <th className="pb-2 pr-4">Type</th>
+              <th className="pb-2 pr-4">Weight</th>
+              <th className="pb-2">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-900">
+            {edges.map((edge) => (
+              <tr key={edge.id} className="hover:bg-gray-900/50">
+                <td className="py-2 pr-4 font-mono text-xs text-gray-400">{edge.id}</td>
+                <td className="py-2 pr-4">{nodeMap.get(edge.source) ?? edge.source}</td>
+                <td className="py-2 pr-4">{nodeMap.get(edge.target) ?? edge.target}</td>
+                <td className="py-2 pr-4 text-gray-400">{edge.type}</td>
+                <td className="py-2 pr-4 text-gray-400">{edge.weight}</td>
+                <td className="py-2">
+                  <form
+                    action={async () => {
+                      'use server';
+                      await deleteAdminEdge(edge.id);
+                    }}
+                  >
+                    <button
+                      type="submit"
+                      disabled={!databaseConfigured}
+                      className="text-xs text-red-400 hover:text-red-300 disabled:cursor-not-allowed disabled:text-red-900"
+                    >
+                      Delete
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            ))}
+            {edges.length === 0 && (
+              <tr>
+                <td colSpan={6} className="py-6 text-center text-sm text-gray-500">
+                  {databaseConfigured ? 'No graph edges found.' : 'Database connection required.'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -1,0 +1,30 @@
+import { requireAdminUser } from '@/lib/auth';
+import Link from 'next/link';
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  await requireAdminUser();
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 px-6 py-4">
+        <div className="mx-auto flex max-w-6xl items-center gap-6">
+          <span className="text-sm font-semibold uppercase tracking-widest text-gray-400">
+            Admin
+          </span>
+          <nav className="flex gap-4 text-sm">
+            <Link href="/admin/nodes" className="text-gray-400 transition-colors hover:text-white">
+              Nodes
+            </Link>
+            <Link href="/admin/edges" className="text-gray-400 transition-colors hover:text-white">
+              Edges
+            </Link>
+            <Link href="/admin/users" className="text-gray-400 transition-colors hover:text-white">
+              Users
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-8">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/nodes/page.tsx
+++ b/apps/web/src/app/admin/nodes/page.tsx
@@ -1,0 +1,159 @@
+import {
+  createAdminNode,
+  deleteAdminNode,
+  getAdminNodes,
+} from '@/actions/admin-actions';
+import { ADMIN_DOMAINS, ADMIN_NODE_TYPES } from '@/lib/admin-config';
+
+export const dynamic = 'force-dynamic';
+
+const inputCls =
+  'w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-gray-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60';
+const selectCls =
+  'w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-gray-100 focus:border-gray-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60';
+
+export default async function AdminNodesPage() {
+  const databaseConfigured = Boolean(process.env.DATABASE_URL);
+  const nodes = databaseConfigured ? await getAdminNodes() : [];
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="mb-1 text-xl font-semibold">Graph Nodes</h1>
+        <p className="text-sm text-gray-400">{nodes.length} nodes total</p>
+      </div>
+
+      {!databaseConfigured && (
+        <div className="rounded-xl border border-amber-700/40 bg-amber-950/40 p-4 text-sm text-amber-200">
+          Set `DATABASE_URL` before using admin node management. The public app can run in fallback
+          mode, but `/admin` reads and writes the PostgreSQL graph tables directly.
+        </div>
+      )}
+
+      <form
+        action={async (formData: FormData) => {
+          'use server';
+          await createAdminNode({
+            id: formData.get('id') as string,
+            label: formData.get('label') as string,
+            domain: formData.get('domain') as string,
+            level: Number(formData.get('level')),
+            difficulty: Number(formData.get('difficulty')),
+            type: formData.get('type') as string,
+          });
+        }}
+        className="grid grid-cols-2 gap-3 rounded-xl border border-gray-800 p-4 md:grid-cols-3"
+      >
+        <h2 className="col-span-full text-sm font-medium text-gray-300">Add Node</h2>
+        <input name="id" placeholder="id (slug)" required disabled={!databaseConfigured} className={inputCls} />
+        <input name="label" placeholder="label" required disabled={!databaseConfigured} className={inputCls} />
+        <select
+          name="domain"
+          required
+          defaultValue={ADMIN_DOMAINS[0]}
+          disabled={!databaseConfigured}
+          className={selectCls}
+        >
+          {ADMIN_DOMAINS.map((domain) => (
+            <option key={domain} value={domain}>
+              {domain}
+            </option>
+          ))}
+        </select>
+        <input
+          name="level"
+          type="number"
+          placeholder="level (0-5)"
+          defaultValue="1"
+          min="0"
+          max="5"
+          required
+          disabled={!databaseConfigured}
+          className={inputCls}
+        />
+        <input
+          name="difficulty"
+          type="number"
+          placeholder="difficulty (1-5)"
+          defaultValue="2"
+          min="1"
+          max="5"
+          required
+          disabled={!databaseConfigured}
+          className={inputCls}
+        />
+        <select
+          name="type"
+          required
+          defaultValue={ADMIN_NODE_TYPES[0]}
+          disabled={!databaseConfigured}
+          className={selectCls}
+        >
+          {ADMIN_NODE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          disabled={!databaseConfigured}
+          className="col-span-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-950 disabled:text-indigo-300"
+        >
+          Add Node
+        </button>
+      </form>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-800 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th className="pb-2 pr-4">ID</th>
+              <th className="pb-2 pr-4">Label</th>
+              <th className="pb-2 pr-4">Domain</th>
+              <th className="pb-2 pr-4">Level</th>
+              <th className="pb-2 pr-4">Diff</th>
+              <th className="pb-2 pr-4">Type</th>
+              <th className="pb-2">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-900">
+            {nodes.map((node) => (
+              <tr key={node.id} className="hover:bg-gray-900/50">
+                <td className="py-2 pr-4 font-mono text-xs text-gray-400">{node.id}</td>
+                <td className="py-2 pr-4">{node.label}</td>
+                <td className="py-2 pr-4 text-gray-400">{node.domain}</td>
+                <td className="py-2 pr-4 text-gray-400">{node.level}</td>
+                <td className="py-2 pr-4 text-gray-400">{node.difficulty}</td>
+                <td className="py-2 pr-4 text-gray-400">{node.type}</td>
+                <td className="py-2">
+                  <form
+                    action={async () => {
+                      'use server';
+                      await deleteAdminNode(node.id);
+                    }}
+                  >
+                    <button
+                      type="submit"
+                      disabled={!databaseConfigured}
+                      className="text-xs text-red-400 hover:text-red-300 disabled:cursor-not-allowed disabled:text-red-900"
+                    >
+                      Delete
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            ))}
+            {nodes.length === 0 && (
+              <tr>
+                <td colSpan={7} className="py-6 text-center text-sm text-gray-500">
+                  {databaseConfigured ? 'No graph nodes found.' : 'Database connection required.'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminPage() {
+  redirect('/admin/nodes');
+}

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -1,0 +1,58 @@
+import { getAdminUsers } from '@/actions/admin-actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminUsersPage() {
+  const databaseConfigured = Boolean(process.env.DATABASE_URL);
+  const users = databaseConfigured ? await getAdminUsers() : [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="mb-1 text-xl font-semibold">Users</h1>
+        <p className="text-sm text-gray-400">{users.length} active users</p>
+      </div>
+
+      {!databaseConfigured && (
+        <div className="rounded-xl border border-amber-700/40 bg-amber-950/40 p-4 text-sm text-amber-200">
+          Set `DATABASE_URL` before viewing user knowledge summaries. This page queries
+          `user_knowledge_states` directly.
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-800 text-left text-xs uppercase tracking-wide text-gray-500">
+              <th className="pb-2 pr-4">Clerk ID</th>
+              <th className="pb-2 pr-4">Known</th>
+              <th className="pb-2 pr-4">Partial</th>
+              <th className="pb-2 pr-4">Total seen</th>
+              <th className="pb-2">Last active</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-900">
+            {users.map((user) => (
+              <tr key={user.user_id} className="hover:bg-gray-900/50">
+                <td className="py-2 pr-4 font-mono text-xs text-gray-400">{user.user_id}</td>
+                <td className="py-2 pr-4 text-green-400">{user.known}</td>
+                <td className="py-2 pr-4 text-yellow-400">{user.partial}</td>
+                <td className="py-2 pr-4 text-gray-400">{user.total}</td>
+                <td className="py-2 text-xs text-gray-400">
+                  {user.last_updated ? new Date(user.last_updated).toLocaleDateString() : '—'}
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
+                  {databaseConfigured ? 'No user knowledge data found.' : 'Database connection required.'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/admin-config.ts
+++ b/apps/web/src/lib/admin-config.ts
@@ -1,0 +1,22 @@
+export const ADMIN_NODE_TYPES = ['concept', 'theorem', 'algorithm', 'model'] as const;
+
+export const ADMIN_DOMAINS = [
+  'ml',
+  'dl',
+  'nlp',
+  'cv',
+  'rl',
+  'math',
+  'stats',
+  'systems',
+  'general',
+  'signal',
+] as const;
+
+export const ADMIN_EDGE_TYPES = [
+  'prerequisite',
+  'related',
+  'generalizes',
+  'derived_from',
+  'equivalent_to',
+] as const;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -29,3 +29,10 @@ export async function requireCurrentUser(): Promise<AuthUser> {
   if (!user) redirect('/login');
   return user;
 }
+
+export async function requireAdminUser(): Promise<AuthUser> {
+  const user = await requireCurrentUser();
+  const adminId = process.env.ADMIN_CLERK_USER_ID;
+  if (!adminId || user.id !== adminId) redirect('/');
+  return user;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This folder contains technical documentation for the Personal STEM Brain project
 - [API Specification](./reference/api-spec.md)
 - [Data Model](./reference/data-model.md)
 - [Development & Operations](./operations/development.md)
+- [Admin Operations](./operations/admin.md)
 
 ## Reading Order
 
@@ -19,3 +20,4 @@ This folder contains technical documentation for the Personal STEM Brain project
 4. API Specification
 5. Knowledge Graph Spec
 6. Development & Operations
+7. Admin Operations (if working on `/admin`)

--- a/docs/operations/admin.md
+++ b/docs/operations/admin.md
@@ -1,0 +1,53 @@
+# Admin Operations
+
+The `/admin` routes are intended for a single trusted Clerk user and operate only on the
+PostgreSQL-backed graph tables in `apps/web`.
+
+## Required Environment Variables
+
+Set these before using `/admin`:
+
+```bash
+DATABASE_URL=postgres://user:password@host/db?sslmode=require
+ADMIN_CLERK_USER_ID=user_...
+```
+
+- `DATABASE_URL` is required because the admin pages read and write `graph_nodes`,
+  `graph_edges`, and `user_knowledge_states` directly.
+- `ADMIN_CLERK_USER_ID` must match the Clerk user id for the only account allowed to access
+  `/admin`.
+
+Use the web app templates as your source of truth:
+
+- `apps/web/.env.dev.example`
+- `apps/web/.env.prod.example`
+
+## Route Behavior
+
+- Signed-out users are redirected to `/login`.
+- Signed-in non-admin users are redirected to `/`.
+- `/admin` redirects to `/admin/nodes`.
+- All mutations re-check admin authorization in the server action before executing.
+
+## Supported Operations
+
+- Nodes: list, create, delete
+- Edges: list, create, delete
+- Users: view aggregated learning progress
+
+## Validation Rules
+
+- Node ids are normalized to lowercase with spaces converted to underscores.
+- Node `level` must be between `0` and `5`.
+- Node `difficulty` must be between `1` and `5`.
+- Edge `weight` must be between `0` and `1`.
+- Edge source and target must be different nodes.
+
+## Verification
+
+1. Add your Clerk user id to `ADMIN_CLERK_USER_ID`.
+2. Start the web app with a valid `DATABASE_URL`.
+3. Visit `/admin/nodes` and verify existing rows load.
+4. Create and delete a node.
+5. Create and delete an edge.
+6. Visit `/admin/users` and verify user aggregates render.

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -36,6 +36,10 @@ When changing graph behavior, update docs in this order:
 3. `docs/reference/knowledge-graph-spec.md`
 4. `README.md` summary links
 
+When changing `/admin`, also update:
+
+5. `docs/operations/admin.md`
+
 ## Graph Taxonomy Change Workflow
 
 1. Update nodes in `src/data/graph-nodes.ts`.
@@ -82,3 +86,7 @@ See `DEPLOY.md` for full runbook and CI template.
 3. Port bind errors
 - Another process holds the port.
 - Switch port or stop the existing process.
+
+4. `/admin` looks empty or actions fail immediately
+- Confirm `DATABASE_URL` is set. Admin pages do not support the in-memory fallback mode.
+- Confirm `ADMIN_CLERK_USER_ID` matches the Clerk user id for the signed-in admin account.


### PR DESCRIPTION
## Summary
- add an admin-only  section for managing graph nodes, edges, and user summaries
- enforce per-action admin authorization plus server-side validation for admin mutations
- document the required admin environment variables and operational workflow

## Testing
- pnpm --filter @stem-brain/web check
- pnpm --filter @stem-brain/web build