### PR TITLE
fix: tone down homepage background

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -58,80 +58,26 @@ body {
 
 .home-grid-lines {
   background-image:
-    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+    linear-gradient(rgba(148, 163, 184, 0.065) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.065) 1px, transparent 1px);
   background-size: 56px 56px;
   mask-image: radial-gradient(circle at 72% 42%, black, transparent 68%);
   animation: homeGridDrift 18s linear infinite;
 }
 
-.home-art-cycle {
-  opacity: 0.72;
-  transform: translate3d(0, 0, 0);
-}
-
-.home-art-layer {
-  position: absolute;
-  inset: -4%;
-  width: 108%;
-  height: 108%;
-  object-fit: cover;
-  object-position: center right;
-  opacity: 0;
-  filter: saturate(1.08) contrast(1.03);
-  animation: homeArtFade 18s ease-in-out infinite;
-}
-
-.home-art-layer-one {
-  animation-delay: 0s;
-}
-
-.home-art-layer-two {
-  animation-delay: 6s;
-}
-
-.home-art-layer-three {
-  animation-delay: 12s;
+.home-map-contours {
+  background-image:
+    radial-gradient(ellipse at 68% 36%, transparent 0 24%, rgba(125, 211, 252, 0.09) 24.4% 24.8%, transparent 25.2%),
+    radial-gradient(ellipse at 72% 42%, transparent 0 34%, rgba(148, 163, 184, 0.07) 34.3% 34.7%, transparent 35%),
+    radial-gradient(ellipse at 64% 56%, transparent 0 45%, rgba(20, 184, 166, 0.06) 45.3% 45.7%, transparent 46%);
+  animation: homeContourDrift 24s ease-in-out infinite alternate;
 }
 
 .home-scan-beam {
   animation: homeScan 5.5s ease-in-out infinite;
 }
 
-.home-orbit-ring {
-  animation: homeOrbit 9s linear infinite;
-  box-shadow: 0 0 36px rgba(56, 189, 248, 0.14);
-}
-
-.home-orbit-ring::before,
-.home-orbit-ring::after {
-  content: "";
-  position: absolute;
-  width: 0.6rem;
-  height: 0.6rem;
-  border-radius: 999px;
-  background: #67e8f9;
-  box-shadow: 0 0 22px rgba(103, 232, 249, 0.9);
-}
-
-.home-orbit-ring::before {
-  top: -0.3rem;
-  left: 50%;
-}
-
-.home-orbit-ring::after {
-  right: 1.2rem;
-  bottom: 2.7rem;
-  background: #fbbf24;
-  box-shadow: 0 0 22px rgba(251, 191, 36, 0.78);
-}
-
-.home-orbit-ring-slow {
-  animation-duration: 14s;
-  animation-direction: reverse;
-}
-
-.home-art-showcase,
+.home-knowledge-surface,
 .home-stat-tile {
   animation: homePanelPulse 5.6s ease-in-out infinite;
 }
@@ -140,22 +86,51 @@ body {
   animation: homeStatusBlink 1.7s ease-in-out infinite;
 }
 
-.home-showcase-image {
-  opacity: 0;
-  transform: scale(1.05);
-  animation: homeShowcaseFade 18s ease-in-out infinite;
+.home-surface-grid {
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
 }
 
-.home-showcase-image-one {
-  animation-delay: 0s;
+.home-node-map {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-.home-showcase-image-two {
-  animation-delay: 6s;
+.home-map-node {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  min-width: 4.5rem;
+  height: 2.25rem;
+  place-items: center;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+  animation: homeNodeFloat 7s ease-in-out infinite;
 }
 
-.home-showcase-image-three {
-  animation-delay: 12s;
+.home-map-node-core {
+  min-width: 4rem;
+  border-radius: 999px;
+  animation-duration: 8.5s;
+}
+
+.home-map-line {
+  position: absolute;
+  z-index: 1;
+  height: 1px;
+  transform-origin: center;
+  background: linear-gradient(90deg, transparent, rgba(125, 211, 252, 0.34), transparent);
+}
+
+.home-progress-line {
+  animation: homeProgressPulse 4.8s ease-in-out infinite;
 }
 
 @keyframes drift {
@@ -167,28 +142,21 @@ body {
   }
 }
 
-@keyframes homeArtFade {
-  0%,
-  100% {
-    opacity: 0;
-    transform: scale(1.02) translate3d(0, 0, 0);
-  }
-  8%,
-  28% {
-    opacity: 0.82;
-  }
-  42% {
-    opacity: 0;
-    transform: scale(1.09) translate3d(-1.6%, -0.8%, 0);
-  }
-}
-
 @keyframes homeGridDrift {
   from {
     background-position: 0 0, 0 0;
   }
   to {
     background-position: 56px 56px, 56px 56px;
+  }
+}
+
+@keyframes homeContourDrift {
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  to {
+    transform: translate3d(-1.5%, 1%, 0) scale(1.04);
   }
 }
 
@@ -204,18 +172,6 @@ body {
   }
   50% {
     transform: translateX(24vw) rotate(12deg);
-  }
-}
-
-@keyframes homeOrbit {
-  from {
-    transform: rotate(0deg) scale(1);
-  }
-  50% {
-    transform: rotate(180deg) scale(1.04);
-  }
-  to {
-    transform: rotate(360deg) scale(1);
   }
 }
 
@@ -241,19 +197,23 @@ body {
   }
 }
 
-@keyframes homeShowcaseFade {
+@keyframes homeNodeFloat {
   0%,
   100% {
-    opacity: 0;
-    transform: scale(1.04) translate3d(0, 0, 0);
+    transform: translateY(0);
   }
-  8%,
-  30% {
+  50% {
+    transform: translateY(-5px);
+  }
+}
+
+@keyframes homeProgressPulse {
+  0%,
+  100% {
+    opacity: 0.72;
+  }
+  50% {
     opacity: 1;
-  }
-  43% {
-    opacity: 0;
-    transform: scale(1.12) translate3d(-2%, -1.4%, 0);
   }
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import Navbar from '@/components/navbar';
 import HomeGraphScene from '@/components/home-graph-scene';
 import { getCurrentUser } from '@/lib/auth';
@@ -23,7 +22,7 @@ export default async function HomePage() {
       <HomeGraphScene {...sceneStats} />
       <Navbar />
 
-      <section className="relative mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col justify-start px-6 pb-14 pt-10 md:pb-20 md:pt-14">
+      <section className="relative z-10 mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col justify-start px-6 pb-14 pt-10 md:pb-20 md:pt-14">
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
           <div className="fade-up max-w-3xl">
             <p className="inline-flex items-center gap-2 rounded-full border border-sky-300/35 bg-sky-300/10 px-3 py-1 text-xs font-semibold uppercase text-sky-100 shadow-sm backdrop-blur">
@@ -90,7 +89,7 @@ export default async function HomePage() {
           </div>
 
           <div className="fade-up">
-            <ArtShowcase
+            <KnowledgeSurface
               known={sceneStats.known}
               saved={sceneStats.saved}
               notes={sceneStats.notes}
@@ -127,7 +126,7 @@ function StatBox({
   );
 }
 
-function ArtShowcase({
+function KnowledgeSurface({
   known,
   saved,
   notes,
@@ -136,48 +135,60 @@ function ArtShowcase({
   saved: number;
   notes: number;
 }) {
+  const rows = [
+    { label: 'Linear systems', value: 82, tone: 'bg-emerald-300' },
+    { label: 'Bayes rule', value: 64, tone: 'bg-sky-300' },
+    { label: 'Fourier analysis', value: 48, tone: 'bg-amber-300' },
+    { label: 'Graph search', value: 72, tone: 'bg-cyan-300' },
+  ];
+
   return (
-    <div className="home-art-showcase relative min-h-[30rem] overflow-hidden rounded-lg">
-      <div className="absolute inset-x-8 bottom-3 h-12 bg-cyan-500/20 blur-3xl" />
-      <div className="relative min-h-[30rem] overflow-hidden rounded-lg bg-slate-950/20">
-        <Image
-          src="/home-art/knowledge-brain.png"
-          alt=""
-          fill
-          sizes="(min-width: 1024px) 420px, 100vw"
-          className="home-showcase-image home-showcase-image-one object-cover"
-        />
-        <Image
-          src="/home-art/domain-atlas.png"
-          alt=""
-          fill
-          sizes="(min-width: 1024px) 420px, 100vw"
-          className="home-showcase-image home-showcase-image-two object-cover"
-        />
-        <Image
-          src="/home-art/memory-vault.png"
-          alt=""
-          fill
-          sizes="(min-width: 1024px) 420px, 100vw"
-          className="home-showcase-image home-showcase-image-three object-cover"
-        />
-        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(2,6,23,0.42)_0%,rgba(2,6,23,0.12)_36%,rgba(2,6,23,0.9)_100%)]" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_24%_18%,rgba(45,212,191,0.24),transparent_30%),radial-gradient(circle_at_82%_62%,rgba(251,191,36,0.18),transparent_28%)]" />
-        <div className="absolute left-5 right-5 top-5 flex items-start justify-between gap-4">
-          <div>
-            <p className="text-xs font-semibold uppercase text-slate-300">Artful graph model</p>
-            <h2 className="mt-2 max-w-xs text-2xl font-bold tracking-tight text-white">Brain graph to memory vault</h2>
+    <div className="home-knowledge-surface relative min-h-[30rem] overflow-hidden rounded-lg border border-white/10 bg-slate-950/35 p-5 shadow-2xl shadow-black/25 backdrop-blur">
+      <div className="home-surface-grid absolute inset-0 opacity-70" />
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-200/40 to-transparent" />
+      <div className="relative flex h-full min-h-[27.5rem] flex-col justify-between">
+        <div>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase text-slate-400">Knowledge system</p>
+              <h2 className="mt-2 max-w-xs text-2xl font-bold tracking-tight text-white">A calmer map of what you know</h2>
+            </div>
+            <span className="home-status-pill mt-1 h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_18px_rgba(110,231,183,0.72)]" />
           </div>
-          <span className="home-status-pill mt-1 h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_22px_rgba(110,231,183,0.85)]" />
+
+          <div className="home-node-map relative mt-8 h-52 rounded-lg border border-white/10 bg-slate-900/30">
+            <span className="home-map-node home-map-node-core left-[45%] top-[38%] h-16 w-16 border-white/30 bg-white/12 text-white">
+              Core
+            </span>
+            <span className="home-map-node left-[12%] top-[18%] border-emerald-200/30 bg-emerald-300/12 text-emerald-100">Known</span>
+            <span className="home-map-node right-[13%] top-[14%] border-sky-200/30 bg-sky-300/12 text-sky-100">Review</span>
+            <span className="home-map-node bottom-[12%] left-[18%] border-amber-200/30 bg-amber-300/12 text-amber-100">Notes</span>
+            <span className="home-map-node bottom-[18%] right-[16%] border-cyan-200/30 bg-cyan-300/12 text-cyan-100">Links</span>
+            <span className="home-map-line left-[26%] top-[31%] w-[30%] rotate-[18deg]" />
+            <span className="home-map-line right-[27%] top-[32%] w-[24%] rotate-[-22deg]" />
+            <span className="home-map-line bottom-[31%] left-[28%] w-[28%] rotate-[-20deg]" />
+            <span className="home-map-line bottom-[34%] right-[26%] w-[28%] rotate-[22deg]" />
+          </div>
         </div>
-        <div className="pointer-events-none absolute left-5 top-28 flex flex-col gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-cyan-100/80">
-          <span>Concept map</span>
-          <span className="ml-10 text-amber-100/80">STEM atlas</span>
-          <span className="ml-4 text-emerald-100/80">Memory vault</span>
+
+        <div className="mt-6 space-y-3">
+          {rows.map((row) => (
+            <div key={row.label} className="grid grid-cols-[7.5rem_1fr_2rem] items-center gap-3 text-xs">
+              <span className="text-slate-400">{row.label}</span>
+              <span className="h-1.5 overflow-hidden rounded-full bg-white/10">
+                <span
+                  className={`home-progress-line block h-full rounded-full ${row.tone}`}
+                  style={{ width: `${row.value}%` }}
+                />
+              </span>
+              <span className="text-right text-slate-500">{row.value}</span>
+            </div>
+          ))}
         </div>
-        <div className="absolute bottom-5 left-5 right-5">
+
+        <div className="mt-6">
           <p className="max-w-sm text-sm leading-6 text-slate-200">
-            The scene moves through concept maps, STEM domains, and private notes while the knowledge network rebalances behind it.
+            Concepts, weak spots, notes, and review paths stay connected as your practice history changes.
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs uppercase text-slate-400">
             <span><strong className="mr-1 text-base text-emerald-200">{known}</strong>known</span>

--- a/apps/web/src/components/home-graph-scene.tsx
+++ b/apps/web/src/components/home-graph-scene.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
 
 const ForceGraph3D = dynamic(() => import('react-force-graph-3d'), {
@@ -184,38 +183,13 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
       ref={wrapperRef}
       aria-hidden="true"
       onPointerMove={handlePointerMove}
-      className="pointer-events-none absolute inset-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%]"
+      className="pointer-events-none absolute inset-0 z-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%]"
     >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_72%_36%,rgba(14,165,233,0.24),transparent_34%),radial-gradient(circle_at_26%_68%,rgba(245,158,11,0.18),transparent_30%),linear-gradient(135deg,#020617_0%,#0f172a_54%,#111827_100%)]" />
-      <div className="home-art-cycle absolute inset-0">
-        <Image
-          src="/home-art/knowledge-brain.png"
-          alt=""
-          fill
-          priority
-          sizes="100vw"
-          className="home-art-layer home-art-layer-one"
-        />
-        <Image
-          src="/home-art/domain-atlas.png"
-          alt=""
-          fill
-          sizes="100vw"
-          className="home-art-layer home-art-layer-two"
-        />
-        <Image
-          src="/home-art/memory-vault.png"
-          alt=""
-          fill
-          sizes="100vw"
-          className="home-art-layer home-art-layer-three"
-        />
-      </div>
-      <div className="home-grid-lines absolute inset-0 opacity-60" />
-      <div className="home-scan-beam absolute inset-y-[-20%] left-[52%] w-24 rotate-12 bg-gradient-to-r from-transparent via-cyan-300/16 to-transparent blur-sm" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_var(--pointer-x)_var(--pointer-y),rgba(255,255,255,0.18),transparent_18rem)] transition-[background] duration-300" />
-      <div className="absolute right-[8%] top-[16%] hidden h-52 w-52 rounded-full border border-cyan-200/15 md:block home-orbit-ring" />
-      <div className="absolute right-[18%] top-[28%] hidden h-80 w-80 rounded-full border border-emerald-200/10 md:block home-orbit-ring home-orbit-ring-slow" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_72%_36%,rgba(14,165,233,0.16),transparent_34%),radial-gradient(circle_at_26%_68%,rgba(20,184,166,0.12),transparent_30%),linear-gradient(135deg,#020617_0%,#0b1120_54%,#111827_100%)]" />
+      <div className="home-grid-lines absolute inset-0 opacity-55" />
+      <div className="home-map-contours absolute inset-0 opacity-35" />
+      <div className="home-scan-beam absolute inset-y-[-20%] left-[52%] w-16 rotate-12 bg-gradient-to-r from-transparent via-cyan-300/[0.08] to-transparent blur-sm" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_var(--pointer-x)_var(--pointer-y),rgba(255,255,255,0.08),transparent_18rem)] transition-[background] duration-300" />
       <div className="pointer-events-auto absolute inset-y-0 right-[-12%] w-[82%] opacity-95 md:right-[-4%] md:w-[68%]">
         <ForceGraph3D
           ref={graphRef}


### PR DESCRIPTION
Removes the generated-art-heavy homepage treatment and replaces it with a quieter graph/UI surface.\n\nChanges:\n- Removes generated bitmap art layers from the homepage background.\n- Replaces the right-side art showcase with a restrained knowledge-system surface.\n- Reduces glowing sci-fi rings and keeps the existing Three.js graph as the dynamic background element.\n- Pins the background layer behind the hero content.\n\nChecks:\n- pnpm --dir apps/web lint\n- pnpm --dir apps/web typecheck\n- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ci_build_placeholder_1234567890 pnpm --dir apps/web build:cf