### PR TITLE
fix: improve responsive homepage graph placement

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -77,6 +77,26 @@ body {
   animation: homeScan 5.5s ease-in-out infinite;
 }
 
+.home-graph-hero {
+  inset: 0;
+  border-radius: 0;
+  mask-image: linear-gradient(to bottom, black 0%, black 78%, transparent 100%);
+}
+
+.home-graph-section .home-graph-canvas {
+  inset-block: 0;
+  right: -12%;
+  width: 82%;
+}
+
+.home-graph-hero .home-graph-canvas {
+  top: 14rem;
+  right: -34%;
+  width: 116%;
+  height: 32rem;
+  opacity: 0.46;
+}
+
 .home-knowledge-surface,
 .home-stat-tile {
   animation: homePanelPulse 5.6s ease-in-out infinite;
@@ -214,6 +234,31 @@ body {
   }
   50% {
     opacity: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .home-graph-hero .home-graph-canvas {
+    top: 5rem;
+    right: -18%;
+    width: 76%;
+    height: 38rem;
+    opacity: 0.46;
+  }
+}
+
+@media (min-width: 1024px) {
+  .home-graph-section .home-graph-canvas {
+    right: -4%;
+    width: 68%;
+  }
+
+  .home-graph-hero .home-graph-canvas {
+    top: 2.5rem;
+    right: -10%;
+    width: 62%;
+    height: 42rem;
+    opacity: 0.55;
   }
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,16 +27,17 @@ export default async function HomePage() {
       <Navbar />
 
       <section className="relative z-10 mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col justify-start px-6 pb-14 pt-10 md:pb-20 md:pt-14">
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
-          <div className="fade-up max-w-3xl">
+        <HomeGraphScene {...sceneStats} placement="hero" />
+        <div className="relative z-10 grid min-w-0 gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
+          <div className="fade-up min-w-0 max-w-3xl">
             <p className="inline-flex items-center gap-2 rounded-full border border-sky-300/35 bg-sky-300/10 px-3 py-1 text-xs font-semibold uppercase text-sky-100 shadow-sm backdrop-blur">
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_18px_rgba(52,211,153,0.9)]" />
               Personal STEM Practice Graph
             </p>
-            <h1 className="mt-5 text-4xl font-black tracking-tight text-white md:text-6xl">
+            <h1 className="mt-5 max-w-[19rem] text-2xl font-black leading-tight tracking-tight text-white sm:max-w-2xl sm:text-4xl md:text-6xl">
               Practice STEM concepts and build your knowledge graph.
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300 md:text-lg">
+            <p className="mt-5 max-w-[20rem] text-sm leading-7 text-slate-300 sm:max-w-2xl sm:text-base md:text-lg">
               Learn with focused concept cards, save weak spots for review, and see your progress across AI, CS, math, and engineering in one connected map.
             </p>
 
@@ -92,7 +93,7 @@ export default async function HomePage() {
             ) : null}
           </div>
 
-          <div className="fade-up">
+          <div className="fade-up min-w-0">
             <KnowledgeSurface
               known={sceneStats.known}
               saved={sceneStats.saved}
@@ -103,20 +104,22 @@ export default async function HomePage() {
         <div className="mt-10 h-px w-full bg-gradient-to-r from-transparent via-white/20 to-transparent" />
       </section>
 
-      <section className="relative z-10 border-t border-white/10 px-6 py-16 md:py-20">
-        <div className="mx-auto max-w-6xl">
-          <div className="max-w-2xl">
-            <p className="text-xs font-semibold uppercase text-sky-200/80">Live graph view</p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">
-              See how your STEM knowledge connects.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-slate-300">
-              The moving graph stays below the first screen, so the homepage opens with the service message first and the dynamic knowledge map follows as the next section.
-            </p>
+      <section className="relative z-10 border-t border-white/10 px-6 py-14 md:py-16">
+        <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-3">
+          <div>
+            <p className="text-xs font-semibold uppercase text-emerald-200/80">Known</p>
+            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.known}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-400">Concepts marked solid.</p>
           </div>
-
-          <div className="relative mt-8 h-[34rem] overflow-hidden rounded-lg border border-white/10 bg-slate-950/60 shadow-2xl shadow-black/30">
-            <HomeGraphScene {...sceneStats} />
+          <div>
+            <p className="text-xs font-semibold uppercase text-sky-200/80">Review</p>
+            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.saved}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-400">Weak spots kept in queue.</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase text-amber-200/80">Notes</p>
+            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.notes}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-400">Your own knowledge items.</p>
           </div>
         </div>
       </section>

--- a/apps/web/src/components/home-graph-scene.tsx
+++ b/apps/web/src/components/home-graph-scene.tsx
@@ -6,17 +6,14 @@ import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } 
 
 const ForceGraph3D = dynamic(() => import('react-force-graph-3d'), {
   ssr: false,
-  loading: () => (
-    <div className="flex h-full min-h-[24rem] items-center justify-center text-sm text-slate-400">
-      Building graph...
-    </div>
-  ),
+  loading: () => null,
 }) as any;
 
 type HomeGraphSceneProps = {
   known: number;
   saved: number;
   notes: number;
+  placement?: 'hero' | 'section';
 };
 
 const NODE_GROUPS = {
@@ -51,14 +48,15 @@ const TOPICS = [
   'Planning',
 ];
 
-export default function HomeGraphScene({ known, saved, notes }: HomeGraphSceneProps) {
+export default function HomeGraphScene({ known, saved, notes, placement = 'section' }: HomeGraphSceneProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const graphContainerRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<any>(null);
   const [dimensions, setDimensions] = useState({ width: 720, height: 560 });
   const [activeGroup, setActiveGroup] = useState<ActiveGroup>('known');
 
   useEffect(() => {
-    const element = wrapperRef.current;
+    const element = graphContainerRef.current;
     if (!element) return;
 
     const resize = () => {
@@ -183,14 +181,16 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
       ref={wrapperRef}
       aria-hidden="true"
       onPointerMove={handlePointerMove}
-      className="pointer-events-none absolute inset-0 z-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%]"
+      className={`pointer-events-none absolute inset-0 z-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%] ${
+        placement === 'hero' ? 'home-graph-hero' : 'home-graph-section'
+      }`}
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_72%_36%,rgba(14,165,233,0.16),transparent_34%),radial-gradient(circle_at_26%_68%,rgba(20,184,166,0.12),transparent_30%),linear-gradient(135deg,#020617_0%,#0b1120_54%,#111827_100%)]" />
       <div className="home-grid-lines absolute inset-0 opacity-55" />
       <div className="home-map-contours absolute inset-0 opacity-35" />
       <div className="home-scan-beam absolute inset-y-[-20%] left-[52%] w-16 rotate-12 bg-gradient-to-r from-transparent via-cyan-300/[0.08] to-transparent blur-sm" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_var(--pointer-x)_var(--pointer-y),rgba(255,255,255,0.08),transparent_18rem)] transition-[background] duration-300" />
-      <div className="pointer-events-auto absolute inset-y-0 right-[-12%] w-[82%] opacity-95 md:right-[-4%] md:w-[68%]">
+      <div ref={graphContainerRef} className="home-graph-canvas pointer-events-auto absolute opacity-95">
         <ForceGraph3D
           ref={graphRef}
           graphData={graphData}


### PR DESCRIPTION
Improves the homepage knowledge graph placement so it works as a background element on both desktop and mobile.\n\nChanges:\n- Reintroduces the live graph as a hero background element with separate mobile/desktop placement.\n- Measures the actual graph canvas container for better sizing.\n- Removes visible graph loading text from the background.\n- Tightens mobile headline sizing to prevent clipping.\n- Replaces the old lower graph section with compact stat context.\n\nChecks:\n- pnpm --dir apps/web lint\n- pnpm --dir apps/web typecheck\n- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ci_build_placeholder_1234567890 pnpm --dir apps/web build:cf