### PR TITLE
fix: center homepage knowledge graph

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -90,11 +90,12 @@ body {
 }
 
 .home-graph-hero .home-graph-canvas {
-  top: 14rem;
-  right: -34%;
-  width: 116%;
+  top: 13rem;
+  left: 50%;
+  width: 124%;
   height: 32rem;
-  opacity: 0.46;
+  opacity: 0.42;
+  transform: translateX(-50%);
 }
 
 .home-knowledge-surface,
@@ -239,11 +240,12 @@ body {
 
 @media (min-width: 768px) {
   .home-graph-hero .home-graph-canvas {
-    top: 5rem;
-    right: -18%;
-    width: 76%;
+    top: 4.5rem;
+    left: 50%;
+    width: 86%;
     height: 38rem;
-    opacity: 0.46;
+    opacity: 0.42;
+    transform: translateX(-50%);
   }
 }
 
@@ -255,10 +257,11 @@ body {
 
   .home-graph-hero .home-graph-canvas {
     top: 2.5rem;
-    right: -10%;
-    width: 62%;
+    left: 50%;
+    width: 78%;
     height: 42rem;
-    opacity: 0.55;
+    opacity: 0.44;
+    transform: translateX(-50%);
   }
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -30,8 +30,8 @@ export default async function HomePage() {
         <HomeGraphScene {...sceneStats} placement="hero" />
         <div className="relative z-10 grid min-w-0 gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
           <div className="fade-up min-w-0 max-w-3xl">
-            <p className="inline-flex items-center gap-2 rounded-full border border-sky-300/35 bg-sky-300/10 px-3 py-1 text-xs font-semibold uppercase text-sky-100 shadow-sm backdrop-blur">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_18px_rgba(52,211,153,0.9)]" />
+            <p className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-xs font-semibold uppercase text-slate-300 shadow-sm backdrop-blur">
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-cyan-200/80 shadow-[0_0_16px_rgba(125,211,252,0.65)]" />
               Personal STEM Practice Graph
             </p>
             <h1 className="mt-5 max-w-[19rem] text-2xl font-black leading-tight tracking-tight text-white sm:max-w-2xl sm:text-4xl md:text-6xl">


### PR DESCRIPTION
Centers the homepage knowledge graph in the hero background and adjusts the hero label color to match the current homepage style.\n\nChanges:\n- Centers the hero graph canvas at mobile, tablet, and desktop breakpoints.\n- Reduces graph opacity slightly so it stays behind the content.\n- Retunes the top hero label from bright sky blue to a neutral translucent slate pill with a softer cyan dot.\n\nChecks:\n- pnpm --dir apps/web lint\n- pnpm --dir apps/web typecheck\n- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ci_build_placeholder_1234567890 pnpm --dir apps/web build:cf