### PR TITLE
feat: add multidisciplinary home graph section

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -77,30 +77,25 @@ body {
   animation: homeScan 5.5s ease-in-out infinite;
 }
 
-.home-graph-hero {
-  inset: 0;
-  border-radius: 0;
-  mask-image: linear-gradient(to bottom, black 0%, black 78%, transparent 100%);
-}
-
-.home-graph-section .home-graph-canvas {
-  inset-block: 0;
-  right: -12%;
-  width: 82%;
-}
-
-.home-graph-hero .home-graph-canvas {
-  top: 13rem;
-  left: 50%;
-  width: 124%;
-  height: 32rem;
-  opacity: 0.42;
-  transform: translateX(-50%);
-}
-
 .home-knowledge-surface,
 .home-stat-tile {
   animation: homePanelPulse 5.6s ease-in-out infinite;
+}
+
+.home-discipline-rail {
+  mask-image: linear-gradient(90deg, black 0%, black 82%, transparent 100%);
+}
+
+.home-discipline-rail span {
+  animation: homeDisciplinePulse 7s ease-in-out infinite;
+}
+
+.home-discipline-rail span:nth-child(2n) {
+  animation-delay: 1.2s;
+}
+
+.home-discipline-rail span:nth-child(3n) {
+  animation-delay: 2.1s;
 }
 
 .home-status-pill {
@@ -238,30 +233,15 @@ body {
   }
 }
 
-@media (min-width: 768px) {
-  .home-graph-hero .home-graph-canvas {
-    top: 4.5rem;
-    left: 50%;
-    width: 86%;
-    height: 38rem;
-    opacity: 0.42;
-    transform: translateX(-50%);
+@keyframes homeDisciplinePulse {
+  0%,
+  100% {
+    border-color: rgba(255, 255, 255, 0.1);
+    color: rgb(203, 213, 225);
   }
-}
-
-@media (min-width: 1024px) {
-  .home-graph-section .home-graph-canvas {
-    right: -4%;
-    width: 68%;
-  }
-
-  .home-graph-hero .home-graph-canvas {
-    top: 2.5rem;
-    left: 50%;
-    width: 78%;
-    height: 42rem;
-    opacity: 0.44;
-    transform: translateX(-50%);
+  50% {
+    border-color: rgba(125, 211, 252, 0.3);
+    color: rgb(224, 242, 254);
   }
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,19 +27,26 @@ export default async function HomePage() {
       <Navbar />
 
       <section className="relative z-10 mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col justify-start px-6 pb-14 pt-10 md:pb-20 md:pt-14">
-        <HomeGraphScene {...sceneStats} placement="hero" />
         <div className="relative z-10 grid min-w-0 gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
           <div className="fade-up min-w-0 max-w-3xl">
             <p className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-xs font-semibold uppercase text-slate-300 shadow-sm backdrop-blur">
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-cyan-200/80 shadow-[0_0_16px_rgba(125,211,252,0.65)]" />
-              Personal STEM Practice Graph
+              Multidisciplinary Practice Graph
             </p>
             <h1 className="mt-5 max-w-[19rem] text-2xl font-black leading-tight tracking-tight text-white sm:max-w-2xl sm:text-4xl md:text-6xl">
               Practice STEM concepts and build your knowledge graph.
             </h1>
             <p className="mt-5 max-w-[20rem] text-sm leading-7 text-slate-300 sm:max-w-2xl sm:text-base md:text-lg">
-              Learn with focused concept cards, save weak spots for review, and see your progress across AI, CS, math, and engineering in one connected map.
+              Learn with focused concept cards, save weak spots for review, and see your progress across science, engineering, medicine, computing, economics, and design.
             </p>
+
+            <div className="home-discipline-rail mt-7 flex max-w-2xl gap-2 overflow-hidden text-xs font-semibold uppercase text-slate-300">
+              {['Biology', 'Computer science', 'Semiconductor', 'Bio-chemistry', 'Medicine', 'Statistics', 'Economics', 'Architecture'].map((label) => (
+                <span key={label} className="shrink-0 rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 backdrop-blur">
+                  {label}
+                </span>
+              ))}
+            </div>
 
             <div className="mt-8 flex flex-wrap gap-3">
               {user ? (
@@ -62,6 +69,12 @@ export default async function HomePage() {
                   >
                     Progress dashboard
                   </Link>
+                  <Link
+                    href="#knowledge-graph"
+                    className="rounded-lg border border-cyan-200/25 bg-cyan-300/10 px-5 py-3 text-sm font-semibold text-cyan-50 backdrop-blur transition hover:bg-cyan-300/15"
+                  >
+                    See live graph
+                  </Link>
                 </>
               ) : (
                 <>
@@ -76,6 +89,12 @@ export default async function HomePage() {
                     className="rounded-lg border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/15"
                   >
                     Log in
+                  </Link>
+                  <Link
+                    href="#knowledge-graph"
+                    className="rounded-lg border border-cyan-200/25 bg-cyan-300/10 px-5 py-3 text-sm font-semibold text-cyan-50 backdrop-blur transition hover:bg-cyan-300/15"
+                  >
+                    See live graph
                   </Link>
                 </>
               )}
@@ -104,26 +123,40 @@ export default async function HomePage() {
         <div className="mt-10 h-px w-full bg-gradient-to-r from-transparent via-white/20 to-transparent" />
       </section>
 
-      <section className="relative z-10 border-t border-white/10 px-6 py-14 md:py-16">
-        <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-3">
-          <div>
-            <p className="text-xs font-semibold uppercase text-emerald-200/80">Known</p>
-            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.known}</p>
-            <p className="mt-2 text-sm leading-6 text-slate-400">Concepts marked solid.</p>
+      <section id="knowledge-graph" className="relative z-10 scroll-mt-6 border-t border-white/10 px-6 py-16 md:py-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase text-cyan-100/70">Scroll graph view</p>
+              <h2 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">
+                A live map across disciplines.
+              </h2>
+              <p className="mt-4 text-base leading-7 text-slate-300">
+                Concepts from biology, computer science, semiconductors, medicine, statistics, economics, architecture, and chemistry connect in one moving knowledge graph.
+              </p>
+            </div>
+            <div className="grid grid-cols-3 gap-3 text-center">
+              <MiniMetric value={sceneStats.known} label="Known" />
+              <MiniMetric value={sceneStats.saved} label="Review" />
+              <MiniMetric value={sceneStats.notes} label="Notes" />
+            </div>
           </div>
-          <div>
-            <p className="text-xs font-semibold uppercase text-sky-200/80">Review</p>
-            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.saved}</p>
-            <p className="mt-2 text-sm leading-6 text-slate-400">Weak spots kept in queue.</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold uppercase text-amber-200/80">Notes</p>
-            <p className="mt-2 text-3xl font-bold text-white">{sceneStats.notes}</p>
-            <p className="mt-2 text-sm leading-6 text-slate-400">Your own knowledge items.</p>
+
+          <div className="relative mt-8 h-[34rem] overflow-hidden rounded-lg border border-white/10 bg-slate-950/60 shadow-2xl shadow-black/30 md:h-[38rem]">
+            <HomeGraphScene {...sceneStats} />
           </div>
         </div>
       </section>
     </main>
+  );
+}
+
+function MiniMetric({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.05] px-4 py-3 backdrop-blur">
+      <span className="block text-2xl font-bold text-white">{value}</span>
+      <span className="text-xs uppercase text-slate-400">{label}</span>
+    </div>
   );
 }
 

--- a/apps/web/src/components/home-graph-scene.tsx
+++ b/apps/web/src/components/home-graph-scene.tsx
@@ -13,13 +13,12 @@ type HomeGraphSceneProps = {
   known: number;
   saved: number;
   notes: number;
-  placement?: 'hero' | 'section';
 };
 
 const NODE_GROUPS = {
-  known: { color: '#22c55e', hotColor: '#86efac', label: 'Known' },
-  saved: { color: '#38bdf8', hotColor: '#7dd3fc', label: 'Saved' },
-  notes: { color: '#f59e0b', hotColor: '#fcd34d', label: 'Notes' },
+  known: { color: '#2dd4bf', hotColor: '#99f6e4', label: 'Known' },
+  saved: { color: '#60a5fa', hotColor: '#bfdbfe', label: 'Saved' },
+  notes: { color: '#fbbf24', hotColor: '#fde68a', label: 'Notes' },
   core: { color: '#94a3b8', label: 'Concepts' },
 };
 
@@ -28,27 +27,37 @@ type ActiveGroup = keyof Pick<typeof NODE_GROUPS, 'known' | 'saved' | 'notes'>;
 const GROUP_SEQUENCE: ActiveGroup[] = ['known', 'saved', 'notes'];
 
 const TOPICS = [
-  'Linear Systems',
-  'Bayes Rule',
-  'Control Loops',
-  'Fourier Analysis',
-  'Neural Nets',
-  'Graph Search',
-  'Optimization',
-  'Signals',
-  'State Space',
+  'Cell Signaling',
+  'Graph Algorithms',
+  'Semiconductor Physics',
+  'Protein Folding',
+  'Bayesian Inference',
+  'Clinical Trials',
+  'Microeconomics',
+  'Urban Systems',
+  'Organic Chemistry',
+  'Computer Architecture',
+  'Epidemiology',
+  'Control Theory',
+  'Behavioral Economics',
+  'Neural Networks',
+  'Biostatistics',
+  'Materials Science',
+  'Pharmacokinetics',
+  'Sustainable Design',
+  'Operating Systems',
+  'Genomics',
+  'Market Design',
+  'Thermodynamics',
+  'Structural Engineering',
+  'Medical Imaging',
   'Databases',
-  'Computer Vision',
-  'Probability',
-  'Embedded IO',
-  'Compilers',
-  'Distributed Systems',
-  'Feedback',
-  'Transforms',
-  'Planning',
+  'Immunology',
+  'Econometrics',
+  'VLSI Design',
 ];
 
-export default function HomeGraphScene({ known, saved, notes, placement = 'section' }: HomeGraphSceneProps) {
+export default function HomeGraphScene({ known, saved, notes }: HomeGraphSceneProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const graphContainerRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<any>(null);
@@ -181,16 +190,14 @@ export default function HomeGraphScene({ known, saved, notes, placement = 'secti
       ref={wrapperRef}
       aria-hidden="true"
       onPointerMove={handlePointerMove}
-      className={`pointer-events-none absolute inset-0 z-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%] ${
-        placement === 'hero' ? 'home-graph-hero' : 'home-graph-section'
-      }`}
+      className="pointer-events-none absolute inset-0 z-0 overflow-hidden [--pointer-x:72%] [--pointer-y:36%]"
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_72%_36%,rgba(14,165,233,0.16),transparent_34%),radial-gradient(circle_at_26%_68%,rgba(20,184,166,0.12),transparent_30%),linear-gradient(135deg,#020617_0%,#0b1120_54%,#111827_100%)]" />
       <div className="home-grid-lines absolute inset-0 opacity-55" />
       <div className="home-map-contours absolute inset-0 opacity-35" />
       <div className="home-scan-beam absolute inset-y-[-20%] left-[52%] w-16 rotate-12 bg-gradient-to-r from-transparent via-cyan-300/[0.08] to-transparent blur-sm" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_var(--pointer-x)_var(--pointer-y),rgba(255,255,255,0.08),transparent_18rem)] transition-[background] duration-300" />
-      <div ref={graphContainerRef} className="home-graph-canvas pointer-events-auto absolute opacity-95">
+      <div ref={graphContainerRef} className="home-graph-canvas pointer-events-auto absolute inset-y-0 left-1/2 w-[120%] -translate-x-1/2 opacity-95 md:w-[92%] lg:w-[82%]">
         <ForceGraph3D
           ref={graphRef}
           graphData={graphData}
@@ -223,7 +230,7 @@ export default function HomeGraphScene({ known, saved, notes, placement = 'secti
           }}
         />
       </div>
-      <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(2,6,23,0.98)_0%,rgba(2,6,23,0.86)_38%,rgba(2,6,23,0.42)_70%,rgba(2,6,23,0.18)_100%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_48%,transparent_0%,rgba(2,6,23,0.08)_58%,rgba(2,6,23,0.5)_100%)]" />
       <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-slate-950 to-transparent" />
     </div>
   );


### PR DESCRIPTION
## Summary
- move the 3D knowledge graph out of the hero into a scroll-down home section
- add a more active discipline rail and live graph CTA
- expand graph node labels across biology, CS, semiconductors, bio-chemistry, statistics, medicine, economics, architecture, and related fields

## Checks
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ci_build_placeholder_1234567890 pnpm --dir apps/web build:cf