### PR TITLE
Add persistent knowledge evidence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ This project implements an AI/CS knowledge graph MVP with:
 - API routes:
   - `src/app/api/graph/route.ts`
   - `src/app/api/quiz_result/route.ts`
+  - `src/app/api/knowledge-profile/route.ts`
+  - `src/app/api/knowledge-context/route.ts`
 - PostgreSQL schema: `schema.sql`
 
 ## API
 
 ### `GET /api/graph`
 Returns full graph payload (`nodes`, `links`) plus aggregate stats for the signed-in user.
+
+### `GET /api/knowledge-profile`
+Returns a machine-readable per-user knowledge profile JSON for MCP/tooling integration.
+
+### `GET /api/knowledge-context`
+Returns a compact AI-ready context payload containing a short `summary` and a prompt-safe `prompt_block`.
 
 ### `GET /api/health`
 Returns health and storage mode:

--- a/apps/web/drizzle/migrations/0003_add_knowledge_evidence_layer.sql
+++ b/apps/web/drizzle/migrations/0003_add_knowledge_evidence_layer.sql
@@ -1,0 +1,104 @@
+-- Additive migration for richer self-report vs verified knowledge modeling.
+-- This keeps the current known/saved flow working while preparing the schema
+-- for a simpler user-facing 3-state UX and a stronger anti-overconfidence model.
+
+ALTER TABLE "user_card_states"
+  ADD COLUMN IF NOT EXISTS "self_report_label" text
+  CHECK ("self_report_label" IN ('unknown', 'partial', 'explainable'));
+
+ALTER TABLE "user_card_states"
+  ADD COLUMN IF NOT EXISTS "is_bookmarked" boolean NOT NULL DEFAULT false;
+
+UPDATE "user_card_states"
+SET "self_report_label" = CASE
+  WHEN "status" = 'known' THEN 'explainable'
+  WHEN "status" = 'saved' THEN 'partial'
+  ELSE 'unknown'
+END
+WHERE "self_report_label" IS NULL;
+
+UPDATE "user_card_states"
+SET "is_bookmarked" = true
+WHERE "status" = 'saved' OR "progress_state" = 'learning';
+
+CREATE INDEX IF NOT EXISTS "idx_user_card_states_self_report_label"
+ON "user_card_states" ("self_report_label");
+
+CREATE INDEX IF NOT EXISTS "idx_user_card_states_is_bookmarked"
+ON "user_card_states" ("is_bookmarked");
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "self_report_level" real NOT NULL DEFAULT 0;
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "verified_level" real NOT NULL DEFAULT 0;
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "source_type" text NOT NULL DEFAULT 'system'
+  CHECK ("source_type" IN ('self_report', 'quiz', 'conversation', 'ai_inferred', 'system', 'migration'));
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "evidence_count" integer NOT NULL DEFAULT 0
+  CHECK ("evidence_count" >= 0);
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "stability_score" real NOT NULL DEFAULT 0
+  CHECK ("stability_score" >= 0 AND "stability_score" <= 1);
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "retrieval_strength" real NOT NULL DEFAULT 0
+  CHECK ("retrieval_strength" >= 0 AND "retrieval_strength" <= 1);
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "explanation_strength" real NOT NULL DEFAULT 0
+  CHECK ("explanation_strength" >= 0 AND "explanation_strength" <= 1);
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "last_self_reported_at" timestamp with time zone;
+
+ALTER TABLE "user_knowledge_states"
+  ADD COLUMN IF NOT EXISTS "last_verified_at" timestamp with time zone;
+
+UPDATE "user_knowledge_states"
+SET
+  "self_report_level" = "knowledge_state",
+  "verified_level" = 0,
+  "source_type" = 'migration',
+  "evidence_count" = CASE WHEN "knowledge_state" > 0 THEN 1 ELSE 0 END,
+  "last_self_reported_at" = COALESCE("last_self_reported_at", "last_updated")
+WHERE
+  "self_report_level" = 0
+  AND "verified_level" = 0
+  AND "source_type" = 'system'
+  AND "evidence_count" = 0;
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_states_source_type"
+ON "user_knowledge_states" ("source_type");
+
+CREATE TABLE IF NOT EXISTS "user_knowledge_evidence" (
+  "id" serial PRIMARY KEY,
+  "user_id" text NOT NULL,
+  "node_id" text NOT NULL REFERENCES "graph_nodes"("id") ON DELETE cascade,
+  "card_id" text REFERENCES "knowledge_cards"("id") ON DELETE set null,
+  "source_type" text NOT NULL CHECK ("source_type" IN ('self_report', 'quiz', 'conversation', 'ai_inferred', 'system', 'migration')),
+  "event_type" text NOT NULL CHECK ("event_type" IN ('rated_card', 'self_report', 'quiz_pass', 'quiz_fail', 'review', 'bookmark', 'conversation', 'ai_inferred', 'migration')),
+  "score" real,
+  "confidence" real CHECK ("confidence" IS NULL OR ("confidence" >= 0 AND "confidence" <= 1)),
+  "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "created_at" timestamp with time zone DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_evidence_user"
+ON "user_knowledge_evidence" ("user_id");
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_evidence_node"
+ON "user_knowledge_evidence" ("node_id");
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_evidence_source_type"
+ON "user_knowledge_evidence" ("source_type");
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_evidence_event_type"
+ON "user_knowledge_evidence" ("event_type");
+
+CREATE INDEX IF NOT EXISTS "idx_user_knowledge_evidence_created_at"
+ON "user_knowledge_evidence" ("created_at");

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -1,6 +1,8 @@
 import {
+  boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   primaryKey,
   real,
@@ -27,12 +29,16 @@ export const userCardStates = pgTable("user_card_states", {
   userId: text("user_id").notNull(),
   cardId: text("card_id").notNull().references(() => knowledgeCards.id, { onDelete: "cascade" }),
   status: text("status"),
+  selfReportLabel: text("self_report_label"),
+  isBookmarked: boolean("is_bookmarked").notNull().default(false),
   confidence: integer("confidence").default(0),
   lastSeen: timestamp("last_seen", { withTimezone: true }).defaultNow(),
 }, (t) => [
   primaryKey({ columns: [t.userId, t.cardId] }),
   index("idx_user_card_states_user_id").on(t.userId),
   index("idx_user_card_states_status").on(t.status),
+  index("idx_user_card_states_self_report_label").on(t.selfReportLabel),
+  index("idx_user_card_states_is_bookmarked").on(t.isBookmarked),
 ]);
 
 export const graphNodes = pgTable("graph_nodes", {
@@ -67,13 +73,42 @@ export const userKnowledgeStates = pgTable("user_knowledge_states", {
   userId: text("user_id").notNull(),
   nodeId: text("node_id").notNull().references(() => graphNodes.id, { onDelete: "cascade" }),
   knowledgeState: real("knowledge_state").notNull().default(0),
+  selfReportLevel: real("self_report_level").notNull().default(0),
+  verifiedLevel: real("verified_level").notNull().default(0),
+  sourceType: text("source_type").notNull().default("system"),
   confidence: real("confidence").notNull().default(0),
+  evidenceCount: integer("evidence_count").notNull().default(0),
+  stabilityScore: real("stability_score").notNull().default(0),
+  retrievalStrength: real("retrieval_strength").notNull().default(0),
+  explanationStrength: real("explanation_strength").notNull().default(0),
   lastUpdated: timestamp("last_updated", { withTimezone: true }).defaultNow(),
+  lastSelfReportedAt: timestamp("last_self_reported_at", { withTimezone: true }),
+  lastVerifiedAt: timestamp("last_verified_at", { withTimezone: true }),
   firstKnownAt: timestamp("first_known_at", { withTimezone: true }),
 }, (t) => [
   primaryKey({ columns: [t.userId, t.nodeId] }),
   index("idx_user_knowledge_states_user").on(t.userId),
   index("idx_user_knowledge_states_node").on(t.nodeId),
+  index("idx_user_knowledge_states_source_type").on(t.sourceType),
+]);
+
+export const userKnowledgeEvidence = pgTable("user_knowledge_evidence", {
+  id: serial("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  nodeId: text("node_id").notNull().references(() => graphNodes.id, { onDelete: "cascade" }),
+  cardId: text("card_id").references(() => knowledgeCards.id, { onDelete: "set null" }),
+  sourceType: text("source_type").notNull(),
+  eventType: text("event_type").notNull(),
+  score: real("score"),
+  confidence: real("confidence"),
+  metadata: jsonb("metadata").notNull().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+}, (t) => [
+  index("idx_user_knowledge_evidence_user").on(t.userId),
+  index("idx_user_knowledge_evidence_node").on(t.nodeId),
+  index("idx_user_knowledge_evidence_source_type").on(t.sourceType),
+  index("idx_user_knowledge_evidence_event_type").on(t.eventType),
+  index("idx_user_knowledge_evidence_created_at").on(t.createdAt),
 ]);
 
 export const userKnowledgeItems = pgTable("user_knowledge_items", {

--- a/apps/web/schema.sql
+++ b/apps/web/schema.sql
@@ -23,9 +23,11 @@ CREATE TABLE IF NOT EXISTS knowledge_cards (
 
 -- 3. User Card States Table (legacy — kept for backward compatibility)
 CREATE TABLE IF NOT EXISTS user_card_states (
-  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
   card_id TEXT REFERENCES knowledge_cards(id) ON DELETE CASCADE,
   status TEXT CHECK (status IN ('known', 'saved', 'unknown')),
+  self_report_label TEXT CHECK (self_report_label IN ('unknown', 'partial', 'explainable')),
+  is_bookmarked BOOLEAN NOT NULL DEFAULT FALSE,
   confidence INTEGER DEFAULT 0,
   last_seen TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   PRIMARY KEY (user_id, card_id)
@@ -60,18 +62,45 @@ CREATE TABLE IF NOT EXISTS graph_edges (
 
 -- 6. User Knowledge State Table
 CREATE TABLE IF NOT EXISTS user_knowledge_states (
-  user_id UUID NOT NULL,
+  user_id TEXT NOT NULL,
   node_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
   knowledge_state REAL NOT NULL DEFAULT 0 CHECK (knowledge_state IN (0, 0.5, 1)),
+  self_report_level REAL NOT NULL DEFAULT 0 CHECK (self_report_level IN (0, 0.5, 1)),
+  verified_level REAL NOT NULL DEFAULT 0 CHECK (verified_level IN (0, 0.5, 1)),
+  source_type TEXT NOT NULL DEFAULT 'system'
+    CHECK (source_type IN ('self_report', 'quiz', 'conversation', 'ai_inferred', 'system', 'migration')),
   confidence REAL NOT NULL DEFAULT 0 CHECK (confidence >= 0 AND confidence <= 1),
+  evidence_count INTEGER NOT NULL DEFAULT 0 CHECK (evidence_count >= 0),
+  stability_score REAL NOT NULL DEFAULT 0 CHECK (stability_score >= 0 AND stability_score <= 1),
+  retrieval_strength REAL NOT NULL DEFAULT 0 CHECK (retrieval_strength >= 0 AND retrieval_strength <= 1),
+  explanation_strength REAL NOT NULL DEFAULT 0 CHECK (explanation_strength >= 0 AND explanation_strength <= 1),
   last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  last_self_reported_at TIMESTAMP WITH TIME ZONE,
+  last_verified_at TIMESTAMP WITH TIME ZONE,
   first_known_at TIMESTAMP WITH TIME ZONE,
   PRIMARY KEY (user_id, node_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_knowledge_evidence (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  node_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+  card_id TEXT REFERENCES knowledge_cards(id) ON DELETE SET NULL,
+  source_type TEXT NOT NULL
+    CHECK (source_type IN ('self_report', 'quiz', 'conversation', 'ai_inferred', 'system', 'migration')),
+  event_type TEXT NOT NULL
+    CHECK (event_type IN ('rated_card', 'self_report', 'quiz_pass', 'quiz_fail', 'review', 'bookmark', 'conversation', 'ai_inferred', 'migration')),
+  score REAL,
+  confidence REAL CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_user_card_states_user_id ON user_card_states(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_card_states_status ON user_card_states(status);
+CREATE INDEX IF NOT EXISTS idx_user_card_states_self_report_label ON user_card_states(self_report_label);
+CREATE INDEX IF NOT EXISTS idx_user_card_states_is_bookmarked ON user_card_states(is_bookmarked);
 CREATE INDEX IF NOT EXISTS idx_knowledge_cards_domain ON knowledge_cards(domain);
 CREATE INDEX IF NOT EXISTS idx_graph_nodes_domain ON graph_nodes(domain);
 CREATE INDEX IF NOT EXISTS idx_graph_nodes_level ON graph_nodes(level);
@@ -80,6 +109,12 @@ CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_type ON graph_edges(type);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_user ON user_knowledge_states(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_node ON user_knowledge_states(node_id);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_source_type ON user_knowledge_states(source_type);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_user ON user_knowledge_evidence(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_node ON user_knowledge_evidence(node_id);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_source_type ON user_knowledge_evidence(source_type);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_event_type ON user_knowledge_evidence(event_type);
+CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_created_at ON user_knowledge_evidence(created_at);
 
 -- ============================================================
 -- AUTH + USER KNOWLEDGE TABLES

--- a/apps/web/src/actions/admin-actions.ts
+++ b/apps/web/src/actions/admin-actions.ts
@@ -51,8 +51,8 @@ export type AdminEdge = {
 
 export type AdminUser = {
   user_id: string;
-  known: number;
-  partial: number;
+  mastered: number;
+  reinforcing: number;
   total: number;
   last_updated: string | null;
 };
@@ -152,8 +152,8 @@ export async function getAdminUsers(): Promise<AdminUser[]> {
     `SELECT
        user_id,
        COUNT(*)::int                                       AS total,
-       COUNT(*) FILTER (WHERE knowledge_state = 1)::int   AS known,
-       COUNT(*) FILTER (WHERE knowledge_state = 0.5)::int AS partial,
+       COUNT(*) FILTER (WHERE knowledge_state = 1)::int   AS mastered,
+       COUNT(*) FILTER (WHERE knowledge_state = 0.5)::int AS reinforcing,
        MAX(last_updated)                                   AS last_updated
      FROM user_knowledge_states
      GROUP BY user_id

--- a/apps/web/src/actions/card-actions.ts
+++ b/apps/web/src/actions/card-actions.ts
@@ -30,6 +30,7 @@ export type KnowledgeCard = {
 export type CardStatus = 'known' | 'saved';
 type CardKnowledgeState = 'unknown' | 'known';
 type CardProgressState = 'new' | 'learning' | 'review';
+type SelfReportLabel = 'unknown' | 'partial' | 'explainable';
 export type QuizChoiceSet = [string, string, string, string];
 
 export type NodeQuiz = {
@@ -41,6 +42,8 @@ export type NodeQuiz = {
 
 type CardWithStatusRow = KnowledgeCard & {
   status: CardStatus | null;
+  self_report_label?: SelfReportLabel | null;
+  is_bookmarked?: boolean | null;
   knowledge_state?: CardKnowledgeState | null;
   progress_state?: CardProgressState | null;
   due_at?: Date | null;
@@ -382,11 +385,25 @@ async function _initCardSchema() {
       ADD COLUMN IF NOT EXISTS due_at TIMESTAMP WITH TIME ZONE;
   `);
   await pool.query(`
+    ALTER TABLE user_card_states
+      ADD COLUMN IF NOT EXISTS self_report_label TEXT CHECK (self_report_label IN ('unknown', 'partial', 'explainable'));
+  `);
+  await pool.query(`
+    ALTER TABLE user_card_states
+      ADD COLUMN IF NOT EXISTS is_bookmarked BOOLEAN NOT NULL DEFAULT FALSE;
+  `);
+  await pool.query(`
     UPDATE user_card_states
     SET
       knowledge_state = CASE WHEN status = 'known' THEN 'known' ELSE 'unknown' END,
-      progress_state = CASE WHEN status = 'known' THEN 'review' ELSE 'learning' END
-    WHERE knowledge_state IS NULL OR progress_state IS NULL;
+      progress_state = CASE WHEN status = 'known' THEN 'review' ELSE 'learning' END,
+      self_report_label = CASE
+        WHEN status = 'known' THEN 'explainable'
+        WHEN status = 'saved' THEN 'partial'
+        ELSE 'unknown'
+      END,
+      is_bookmarked = CASE WHEN status = 'saved' THEN TRUE ELSE is_bookmarked END
+    WHERE knowledge_state IS NULL OR progress_state IS NULL OR self_report_label IS NULL;
   `);
 
   await pool.query(`
@@ -402,7 +419,78 @@ async function _initCardSchema() {
     CREATE INDEX IF NOT EXISTS idx_user_card_states_due_at ON user_card_states(due_at);
   `);
   await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_card_states_self_report_label ON user_card_states(self_report_label);
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_card_states_is_bookmarked ON user_card_states(is_bookmarked);
+  `);
+  await pool.query(`
     CREATE INDEX IF NOT EXISTS idx_knowledge_cards_domain ON knowledge_cards(domain);
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS self_report_level REAL NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS verified_level REAL NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'system';
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS evidence_count INTEGER NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS stability_score REAL NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS retrieval_strength REAL NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS explanation_strength REAL NOT NULL DEFAULT 0;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS last_self_reported_at TIMESTAMP WITH TIME ZONE;
+  `);
+  await pool.query(`
+    ALTER TABLE user_knowledge_states
+      ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMP WITH TIME ZONE;
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_source_type ON user_knowledge_states(source_type);
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS user_knowledge_evidence (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      node_id TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      card_id TEXT REFERENCES knowledge_cards(id) ON DELETE SET NULL,
+      source_type TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      score REAL,
+      confidence REAL,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_user ON user_knowledge_evidence(user_id);
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_node ON user_knowledge_evidence(node_id);
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_source_type ON user_knowledge_evidence(source_type);
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_event_type ON user_knowledge_evidence(event_type);
   `);
 
   // Skip heavy card content UPSERT when content version is unchanged.
@@ -523,6 +611,11 @@ function normalizeGraphNodeId(nodeId: string): string {
 function mapCardStatusToKnowledge(status: CardStatus): { knowledge: 0 | 0.5 | 1; confidence: number } {
   if (status === 'known') return { knowledge: 1, confidence: 0.8 };
   return { knowledge: 0.5, confidence: 0.45 }; // saved
+}
+
+function mapCardStatusToSelfReportLabel(status: CardStatus): SelfReportLabel {
+  if (status === 'known') return 'explainable';
+  return 'partial';
 }
 
 function deriveLegacyStatus(row: {
@@ -819,22 +912,44 @@ export async function saveCardState(cardId: string, status: CardStatus) {
 
     const mappedKnowledgeState: CardKnowledgeState = status === 'known' ? 'known' : 'unknown';
     const mappedProgressState: CardProgressState = status === 'known' ? 'review' : 'learning';
+    const selfReportLabel = mapCardStatusToSelfReportLabel(status);
+    const isBookmarked = status === 'saved';
     const dueAt = status === 'known'
       ? "NOW() + INTERVAL '14 days'"
       : 'NOW()';
 
     const query = `
-      INSERT INTO user_card_states (user_id, card_id, status, knowledge_state, progress_state, due_at, last_seen)
-      VALUES ($1, $2, $3, $4, $5, ${dueAt}, NOW())
+      INSERT INTO user_card_states (
+        user_id,
+        card_id,
+        status,
+        self_report_label,
+        is_bookmarked,
+        knowledge_state,
+        progress_state,
+        due_at,
+        last_seen
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, ${dueAt}, NOW())
       ON CONFLICT (user_id, card_id)
       DO UPDATE SET
         status = $3,
-        knowledge_state = $4,
-        progress_state = $5,
+        self_report_label = $4,
+        is_bookmarked = $5,
+        knowledge_state = $6,
+        progress_state = $7,
         due_at = ${dueAt},
         last_seen = NOW();
     `;
-    await pool.query(query, [user.id, cardId, status, mappedKnowledgeState, mappedProgressState]);
+    await pool.query(query, [
+      user.id,
+      cardId,
+      status,
+      selfReportLabel,
+      isBookmarked,
+      mappedKnowledgeState,
+      mappedProgressState,
+    ]);
 
     // Sync knowledge graph — secondary operation, failure must not block card save
     try {
@@ -842,14 +957,39 @@ export async function saveCardState(cardId: string, status: CardStatus) {
       const mapped = mapCardStatusToKnowledge(status);
       await pool.query(
         `
-        INSERT INTO user_knowledge_states (user_id, node_id, knowledge_state, confidence, last_updated, first_known_at)
-        SELECT $1, $2, $3, $4, NOW(), CASE WHEN $3 = 1 THEN NOW() ELSE NULL END
+        INSERT INTO user_knowledge_states (
+          user_id,
+          node_id,
+          knowledge_state,
+          self_report_level,
+          verified_level,
+          source_type,
+          confidence,
+          evidence_count,
+          retrieval_strength,
+          explanation_strength,
+          last_updated,
+          last_self_reported_at,
+          first_known_at
+        )
+        SELECT
+          $1, $2, $3, $3, 0, 'self_report', $4,
+          1,
+          CASE WHEN $3 = 1 THEN 0.7 WHEN $3 = 0.5 THEN 0.35 ELSE 0 END,
+          CASE WHEN $3 = 1 THEN 0.8 WHEN $3 = 0.5 THEN 0.3 ELSE 0 END,
+          NOW(), NOW(), CASE WHEN $3 = 1 THEN NOW() ELSE NULL END
         WHERE EXISTS (SELECT 1 FROM graph_nodes WHERE id = $2)
         ON CONFLICT (user_id, node_id)
         DO UPDATE SET
           knowledge_state = EXCLUDED.knowledge_state,
+          self_report_level = EXCLUDED.self_report_level,
+          source_type = 'self_report',
           confidence = EXCLUDED.confidence,
+          evidence_count = user_knowledge_states.evidence_count + 1,
+          retrieval_strength = GREATEST(user_knowledge_states.retrieval_strength, EXCLUDED.retrieval_strength),
+          explanation_strength = GREATEST(user_knowledge_states.explanation_strength, EXCLUDED.explanation_strength),
           last_updated = NOW(),
+          last_self_reported_at = NOW(),
           first_known_at = CASE
             WHEN EXCLUDED.knowledge_state = 1
               THEN COALESCE(user_knowledge_states.first_known_at, NOW())
@@ -857,6 +997,29 @@ export async function saveCardState(cardId: string, status: CardStatus) {
           END;
         `,
         [user.id, nodeId, mapped.knowledge, mapped.confidence]
+      );
+      await pool.query(
+        `
+        INSERT INTO user_knowledge_evidence (
+          user_id,
+          node_id,
+          card_id,
+          source_type,
+          event_type,
+          score,
+          confidence,
+          metadata
+        )
+        VALUES ($1, $2, $3, 'self_report', 'rated_card', $4, $5, $6::jsonb)
+        `,
+        [
+          user.id,
+          nodeId,
+          cardId,
+          mapped.knowledge,
+          mapped.confidence,
+          JSON.stringify({ status, self_report_label: selfReportLabel, progress_state: mappedProgressState }),
+        ]
       );
     } catch (knowledgeErr) {
       // Non-critical: log but don't fail the whole save
@@ -950,7 +1113,7 @@ export async function getUserStats() {
   const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
-    return { known: 12, saved: 5 };
+    return { explainable: 12, unclear: 5 };
   }
 
   try {
@@ -973,12 +1136,12 @@ export async function getUserStats() {
 
     const row = res.rows[0];
     return {
-      known: parseInt(row?.known_count ?? '0', 10),
-      saved: parseInt(row?.saved_count ?? '0', 10),
+      explainable: parseInt(row?.known_count ?? '0', 10),
+      unclear: parseInt(row?.saved_count ?? '0', 10),
     };
   } catch (error) {
     console.error('Error in getUserStats:', error);
-    return { known: 0, saved: 0 };
+    return { explainable: 0, unclear: 0 };
   }
 }
 
@@ -1131,15 +1294,15 @@ export async function resetUserCardProgress() {
 
 export type CardLeaderboardEntry = {
   userId: string;
-  known: number;
+  explainable: number;
   avgScore: number;
 };
 
 export type UserCardDomainProgress = {
   domain: string;
   reviewed: number;
-  known: number;
-  saved: number;
+  explainable: number;
+  unclear: number;
 };
 
 export async function getCardLeaderboard(): Promise<CardLeaderboardEntry[]> {
@@ -1170,7 +1333,7 @@ export async function getCardLeaderboard(): Promise<CardLeaderboardEntry[]> {
       const total = parseInt(row.total_count, 10);
       return {
         userId: row.user_id,
-        known,
+        explainable: known,
         avgScore: total > 0 ? known / total : 0,
       };
     });
@@ -1218,8 +1381,8 @@ export async function getUserCardDomainProgress(): Promise<UserCardDomainProgres
     return res.rows.map((row) => ({
       domain: row.domain,
       reviewed: parseInt(row.reviewed, 10),
-      known: parseInt(row.known, 10),
-      saved: parseInt(row.saved, 10),
+      explainable: parseInt(row.known, 10),
+      unclear: parseInt(row.saved, 10),
     }));
   } catch (error) {
     console.error('Error in getUserCardDomainProgress:', error);

--- a/apps/web/src/actions/graph-actions.ts
+++ b/apps/web/src/actions/graph-actions.ts
@@ -1,19 +1,17 @@
 'use server';
 
-import {
-  getGraphDataForUser,
-  processQuizResult,
-  getUserGraphStats as getUserGraphStatsFromStore,
-  getAllNodes,
-  getAllEdges,
-  getUserKnowledgeState,
-  setUserKnowledgeState,
-  runGlobalDiffusion,
-  getLeaderboard,
-} from '@stem-brain/graph-engine';
 import type { ForceGraphData, GraphNodeWithKnowledge } from '@stem-brain/graph-engine';
 import { revalidatePath } from 'next/cache';
 import { requireCurrentActor } from '@/lib/auth';
+import pool from '@/lib/db';
+import {
+  getDbGraphDataForUser,
+  getDbNodeKnowledge,
+  getDbUserGraphStats,
+  getLeaderboardFromStates,
+  getStaticGraphSummary,
+  submitDbQuizResult,
+} from '@/lib/knowledge-graph-db';
 
 async function getUserId() {
   const user = await requireCurrentActor();
@@ -21,7 +19,7 @@ async function getUserId() {
 }
 
 export async function getGraphData(): Promise<ForceGraphData> {
-  return getGraphDataForUser(await getUserId());
+  return getDbGraphDataForUser(await getUserId());
 }
 
 export async function submitQuizResult(
@@ -35,19 +33,9 @@ export async function submitQuizResult(
   const userId = await getUserId();
 
   try {
-    const { propagatedUpdates } = processQuizResult(userId, nodeId, result);
-    runGlobalDiffusion(userId, 0.3);
-
+    const response = await submitDbQuizResult(userId, nodeId, result);
     revalidatePath('/knowledge');
-
-    const graphData = getGraphDataForUser(userId);
-    const updatedNode = graphData.nodes.find((n) => n.id === nodeId) ?? null;
-
-    return {
-      success: true,
-      node: updatedNode,
-      propagated_count: propagatedUpdates.size,
-    };
+    return response;
   } catch (error) {
     console.error('Error in submitQuizResult:', error);
     return {
@@ -59,11 +47,11 @@ export async function submitQuizResult(
 }
 
 export async function getKnowledgeStats() {
-  return getUserGraphStatsFromStore(await getUserId());
+  return getDbUserGraphStats(await getUserId());
 }
 
 export async function getUserGraphStats() {
-  return getUserGraphStatsFromStore(await getUserId());
+  return getDbUserGraphStats(await getUserId());
 }
 
 export async function batchUpdateKnowledge(
@@ -72,10 +60,28 @@ export async function batchUpdateKnowledge(
   const userId = await getUserId();
 
   try {
-    for (const { nodeId, knowledge, confidence } of updates) {
-      setUserKnowledgeState(userId, nodeId, knowledge, confidence ?? 0.5);
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL is required for graph persistence.');
     }
-
+    for (const { nodeId, knowledge, confidence } of updates) {
+      await pool.query(
+        `
+        INSERT INTO user_knowledge_states (user_id, node_id, knowledge_state, confidence, last_updated, first_known_at)
+        VALUES ($1, $2, $3, $4, NOW(), CASE WHEN $3 = 1 THEN NOW() ELSE NULL END)
+        ON CONFLICT (user_id, node_id)
+        DO UPDATE SET
+          knowledge_state = EXCLUDED.knowledge_state,
+          confidence = EXCLUDED.confidence,
+          last_updated = NOW(),
+          first_known_at = CASE
+            WHEN EXCLUDED.knowledge_state = 1
+              THEN COALESCE(user_knowledge_states.first_known_at, NOW())
+            ELSE user_knowledge_states.first_known_at
+          END
+        `,
+        [userId, nodeId, knowledge >= 0.75 ? 1 : knowledge >= 0.25 ? 0.5 : 0, confidence ?? 0.5]
+      );
+    }
     revalidatePath('/knowledge');
 
     return { success: true, count: updates.length };
@@ -86,10 +92,8 @@ export async function batchUpdateKnowledge(
 }
 
 export async function triggerDiffusion(alpha?: number): Promise<{ success: boolean }> {
-  const userId = await getUserId();
-
   try {
-    runGlobalDiffusion(userId, alpha ?? 0.3);
+    void alpha;
     revalidatePath('/knowledge');
     return { success: true };
   } catch (error) {
@@ -101,47 +105,32 @@ export async function triggerDiffusion(alpha?: number): Promise<{ success: boole
 export async function getNodeKnowledge(
   nodeId: string
 ): Promise<{ knowledge: number; confidence: number } | null> {
-  const state = getUserKnowledgeState(await getUserId(), nodeId);
-
-  if (!state) return { knowledge: 0, confidence: 0 };
-
-  return {
-    knowledge: state.knowledge_state,
-    confidence: state.confidence,
-  };
+  return getDbNodeKnowledge(await getUserId(), nodeId);
 }
 
 export async function getGraphSummary() {
-  const nodes = getAllNodes();
-  const edges = getAllEdges();
-  const domains = [...new Set(nodes.map((n) => n.domain))];
-
-  return {
-    total_nodes: nodes.length,
-    total_edges: edges.length,
-    domains: domains.length,
-    domain_list: domains,
-    level_distribution: {
-      0: nodes.filter((n) => n.level === 0).length,
-      1: nodes.filter((n) => n.level === 1).length,
-      2: nodes.filter((n) => n.level === 2).length,
-    },
-  };
+  return getStaticGraphSummary();
 }
 
 export type LeaderboardData = {
   userId: string;
-  known: number;
+  mastered: number;
   avgScore: number;
 };
 
 export async function getLeaderboardData(): Promise<LeaderboardData[]> {
-  const leaderboard = getLeaderboard();
-  if (leaderboard.length === 0) return [];
-
-  return leaderboard.map((entry) => ({
-    userId: entry.userId,
-    known: entry.known,
-    avgScore: entry.avgKnowledge,
-  }));
+  if (!process.env.DATABASE_URL) return [];
+  const { rows } = await pool.query<{ user_id: string; avg_knowledge: number; known: number }>(
+    `
+    SELECT
+      user_id,
+      COUNT(*) FILTER (WHERE knowledge_state = 1)::int AS known,
+      AVG(knowledge_state)::float8 AS avg_knowledge
+    FROM user_knowledge_states
+    GROUP BY user_id
+    ORDER BY AVG(knowledge_state) DESC, COUNT(*) FILTER (WHERE knowledge_state = 1) DESC
+    LIMIT 50
+    `
+  );
+  return getLeaderboardFromStates(rows);
 }

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -25,8 +25,8 @@ export default async function AdminUsersPage() {
           <thead>
             <tr className="border-b border-gray-800 text-left text-xs uppercase tracking-wide text-gray-500">
               <th className="pb-2 pr-4">Clerk ID</th>
-              <th className="pb-2 pr-4">Known</th>
-              <th className="pb-2 pr-4">Partial</th>
+              <th className="pb-2 pr-4">Mastered</th>
+              <th className="pb-2 pr-4">Reinforcing</th>
               <th className="pb-2 pr-4">Total seen</th>
               <th className="pb-2">Last active</th>
             </tr>
@@ -35,8 +35,8 @@ export default async function AdminUsersPage() {
             {users.map((user) => (
               <tr key={user.user_id} className="hover:bg-gray-900/50">
                 <td className="py-2 pr-4 font-mono text-xs text-gray-400">{user.user_id}</td>
-                <td className="py-2 pr-4 text-green-400">{user.known}</td>
-                <td className="py-2 pr-4 text-yellow-400">{user.partial}</td>
+                <td className="py-2 pr-4 text-green-400">{user.mastered}</td>
+                <td className="py-2 pr-4 text-yellow-400">{user.reinforcing}</td>
                 <td className="py-2 pr-4 text-gray-400">{user.total}</td>
                 <td className="py-2 text-xs text-gray-400">
                   {user.last_updated ? new Date(user.last_updated).toLocaleDateString() : '—'}

--- a/apps/web/src/app/api/graph/route.ts
+++ b/apps/web/src/app/api/graph/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
-import { getGraphDataForUser, getUserGraphStats } from '@stem-brain/graph-engine';
 import { getCurrentActor } from '@/lib/auth';
+import { getDbGraphDataForUser, getDbUserGraphStats } from '@/lib/knowledge-graph-db';
 
 export async function GET() {
   const user = await getCurrentActor();
 
-  const graphData = getGraphDataForUser(user.id);
-  const stats = getUserGraphStats(user.id);
+  const graphData = await getDbGraphDataForUser(user.id);
+  const stats = await getDbUserGraphStats(user.id);
 
   return NextResponse.json({
     ...graphData,

--- a/apps/web/src/app/api/knowledge-context/route.ts
+++ b/apps/web/src/app/api/knowledge-context/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { buildKnowledgeContext } from '@/lib/knowledge-graph-db';
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const context = await buildKnowledgeContext(user.id);
+    return NextResponse.json(context);
+  } catch (error) {
+    console.error('Error in GET /api/knowledge-context:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/knowledge-profile/route.ts
+++ b/apps/web/src/app/api/knowledge-profile/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth';
+import { buildKnowledgeProfile } from '@/lib/knowledge-graph-db';
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const profile = await buildKnowledgeProfile(user.id);
+    return NextResponse.json(profile);
+  } catch (error) {
+    console.error('Error in GET /api/knowledge-profile:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/quiz_result/route.ts
+++ b/apps/web/src/app/api/quiz_result/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { processQuizResult, getGraphDataForUser, runGlobalDiffusion } from '@stem-brain/graph-engine';
 import { getCurrentActor } from '@/lib/auth';
+import { submitDbQuizResult } from '@/lib/knowledge-graph-db';
 
 export async function POST(request: NextRequest) {
   const user = await getCurrentActor();
@@ -23,23 +23,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { directUpdate, propagatedUpdates } = processQuizResult(
+    const response = await submitDbQuizResult(
       user.id,
       node_id,
       result as 0 | 0.5 | 1
     );
-    runGlobalDiffusion(user.id, 0.3);
-
-    const graphData = getGraphDataForUser(user.id);
-    const updatedNode = graphData.nodes.find((n) => n.id === node_id);
 
     return NextResponse.json({
-      success: true,
-      node: updatedNode ?? null,
-      knowledge_state: directUpdate.knowledge_state,
-      confidence: directUpdate.confidence,
-      propagated_count: propagatedUpdates.size,
-      first_known_at: directUpdate.first_known_at,
+      success: response.success,
+      node: response.node,
+      knowledge_state: response.node ? (response.node.knowledge >= 0.75 ? 1 : response.node.knowledge >= 0.25 ? 0.5 : 0) : null,
+      confidence: response.node?.confidence ?? null,
+      propagated_count: response.propagated_count,
     });
   } catch (error) {
     console.error('Error in POST /api/quiz_result:', error);

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -28,15 +28,15 @@ function SummaryBox({
 function DomainCard({
   domain,
   reviewed,
-  known,
-  saved,
+  explainable,
+  unclear,
 }: {
   domain: string;
   reviewed: number;
-  known: number;
-  saved: number;
+  explainable: number;
+  unclear: number;
 }) {
-  const knownPercent = reviewed > 0 ? (known / reviewed) * 100 : 0;
+  const explainablePercent = reviewed > 0 ? (explainable / reviewed) * 100 : 0;
 
   return (
     <div className="rounded-xl border bg-white p-5">
@@ -46,16 +46,16 @@ function DomainCard({
           <p className="mt-1 text-sm text-slate-600">{reviewed} reviewed cards</p>
         </div>
         <div className="rounded-lg bg-slate-50 px-2 py-1 text-xs font-medium text-slate-700">
-          {knownPercent.toFixed(0)}% known
+          {explainablePercent.toFixed(0)}% explainable
         </div>
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
         <div className="rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-emerald-800">
-          Known: {known}
+          Explainable: {explainable}
         </div>
         <div className="rounded border border-blue-200 bg-blue-50 px-2 py-1 text-blue-800">
-          Saved: {saved}
+          Unclear: {unclear}
         </div>
       </div>
     </div>
@@ -65,8 +65,8 @@ function DomainCard({
 export default async function DashboardPage() {
   const [stats, domains] = await Promise.all([getUserStats(), getUserCardDomainProgress()]);
 
-  const totalReviewed = stats.known + stats.saved;
-  const knownPercent = totalReviewed > 0 ? (stats.known / totalReviewed) * 100 : 0;
+  const totalReviewed = stats.explainable + stats.unclear;
+  const explainablePercent = totalReviewed > 0 ? (stats.explainable / totalReviewed) * 100 : 0;
 
   return (
     <main id="main-content" className="min-h-screen bg-gray-50">
@@ -77,7 +77,7 @@ export default async function DashboardPage() {
           <div>
             <h1 className="text-2xl font-bold text-slate-900">Progress Dashboard</h1>
             <p className="mt-1 text-sm text-slate-600">
-              Card progress summary based on your known/saved states.
+              Card progress summary based on what feels explainable vs still unclear.
             </p>
           </div>
           <Link
@@ -106,15 +106,15 @@ export default async function DashboardPage() {
           <>
             <div aria-label="Overall progress summary" className="mt-6 grid grid-cols-3 gap-3">
               <SummaryBox
-                label="Known"
-                value={stats.known}
-                sub={`${knownPercent.toFixed(0)}% of reviewed`}
+                label="Explainable"
+                value={stats.explainable}
+                sub={`${explainablePercent.toFixed(0)}% of reviewed`}
                 colorClass="bg-emerald-50 text-emerald-900 border-emerald-200"
               />
               <SummaryBox
-                label="Saved"
-                value={stats.saved}
-                sub="bookmarked for review"
+                label="Unclear"
+                value={stats.unclear}
+                sub="still needs review"
                 colorClass="bg-blue-50 text-blue-900 border-blue-200"
               />
               <SummaryBox

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,8 +12,8 @@ export default async function HomePage() {
   const userStats = user ? await getUserStats() : null;
   const userKnowledgeItems = user ? await getUserKnowledgeItems() : [];
   const sceneStats = {
-    known: userStats?.known ?? 18,
-    saved: userStats?.saved ?? 7,
+    explainable: userStats?.explainable ?? 18,
+    unclear: userStats?.unclear ?? 7,
     notes: userKnowledgeItems.length || 5,
   };
 
@@ -105,8 +105,8 @@ export default async function HomePage() {
                 aria-label="Your learning stats"
                 className="mt-7 grid max-w-xl grid-cols-3 gap-2"
               >
-                <StatBox value={userStats.known} label="Known" color="text-emerald-200" bg="bg-emerald-400/10 border-emerald-300/20" delay="0ms" />
-                <StatBox value={userStats.saved} label="Saved" color="text-sky-200" bg="bg-sky-400/10 border-sky-300/20" delay="160ms" />
+                <StatBox value={userStats.explainable} label="Explainable" color="text-emerald-200" bg="bg-emerald-400/10 border-emerald-300/20" delay="0ms" />
+                <StatBox value={userStats.unclear} label="Unclear" color="text-sky-200" bg="bg-sky-400/10 border-sky-300/20" delay="160ms" />
                 <StatBox value={userKnowledgeItems.length} label="Notes" color="text-amber-200" bg="bg-amber-400/10 border-amber-300/20" delay="320ms" />
               </div>
             ) : null}
@@ -114,8 +114,8 @@ export default async function HomePage() {
 
           <div className="fade-up min-w-0">
             <KnowledgeSurface
-              known={sceneStats.known}
-              saved={sceneStats.saved}
+              explainable={sceneStats.explainable}
+              unclear={sceneStats.unclear}
               notes={sceneStats.notes}
             />
           </div>
@@ -136,8 +136,8 @@ export default async function HomePage() {
               </p>
             </div>
             <div className="grid grid-cols-3 gap-3 text-center">
-              <MiniMetric value={sceneStats.known} label="Known" />
-              <MiniMetric value={sceneStats.saved} label="Review" />
+              <MiniMetric value={sceneStats.explainable} label="Explainable" />
+              <MiniMetric value={sceneStats.unclear} label="Review" />
               <MiniMetric value={sceneStats.notes} label="Notes" />
             </div>
           </div>
@@ -185,12 +185,12 @@ function StatBox({
 }
 
 function KnowledgeSurface({
-  known,
-  saved,
+  explainable,
+  unclear,
   notes,
 }: {
-  known: number;
-  saved: number;
+  explainable: number;
+  unclear: number;
   notes: number;
 }) {
   const rows = [
@@ -218,7 +218,7 @@ function KnowledgeSurface({
             <span className="home-map-node home-map-node-core left-[45%] top-[38%] h-16 w-16 border-white/30 bg-white/12 text-white">
               Core
             </span>
-            <span className="home-map-node left-[12%] top-[18%] border-emerald-200/30 bg-emerald-300/12 text-emerald-100">Known</span>
+            <span className="home-map-node left-[12%] top-[18%] border-emerald-200/30 bg-emerald-300/12 text-emerald-100">Explain</span>
             <span className="home-map-node right-[13%] top-[14%] border-sky-200/30 bg-sky-300/12 text-sky-100">Review</span>
             <span className="home-map-node bottom-[12%] left-[18%] border-amber-200/30 bg-amber-300/12 text-amber-100">Notes</span>
             <span className="home-map-node bottom-[18%] right-[16%] border-cyan-200/30 bg-cyan-300/12 text-cyan-100">Links</span>
@@ -246,12 +246,12 @@ function KnowledgeSurface({
 
         <div className="mt-6">
           <p className="max-w-sm text-sm leading-6 text-slate-200">
-            Your graph updates as you mark concepts known, keep review items, and add your own notes.
+            Your graph updates as you mark concepts explainable, keep review items, and add your own notes.
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs uppercase text-slate-400">
-            <span><strong className="mr-1 text-base text-emerald-200">{known}</strong>known</span>
+            <span><strong className="mr-1 text-base text-emerald-200">{explainable}</strong>explainable</span>
             <span className="h-1 w-1 rounded-full bg-slate-500" />
-            <span><strong className="mr-1 text-base text-sky-200">{saved}</strong>review</span>
+            <span><strong className="mr-1 text-base text-sky-200">{unclear}</strong>review</span>
             <span className="h-1 w-1 rounded-full bg-slate-500" />
             <span><strong className="mr-1 text-base text-amber-200">{notes}</strong>notes</span>
           </div>

--- a/apps/web/src/app/practice/page.tsx
+++ b/apps/web/src/app/practice/page.tsx
@@ -23,7 +23,7 @@ export default async function PracticePage(props: { searchParams: Promise<{ [key
         <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Practice</h1>
-            <p className="text-sm text-gray-400">Memorize first, then use AI to deepen understanding.</p>
+            <p className="text-sm text-gray-400">Mark what is unclear, and only promote concepts you can actually explain.</p>
           </div>
         </div>
 
@@ -44,8 +44,8 @@ export default async function PracticePage(props: { searchParams: Promise<{ [key
         </div>
         <p className="mb-6 text-xs text-gray-500">
           {mode === 'new'
-            ? 'Learn New: unseen/unknown cards first'
-            : 'Review: cards still in learning queue'}
+            ? 'Learn New: unseen and unclear cards first'
+            : 'Review: concepts you marked as still unclear'}
         </p>
 
         {/* Card viewer — stats are shown inside */}

--- a/apps/web/src/app/ranking/page.tsx
+++ b/apps/web/src/app/ranking/page.tsx
@@ -25,7 +25,7 @@ export default async function RankingPage() {
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Ranking</h1>
             <p className="mt-1 text-sm text-gray-600">
-              Leaderboard based on card progress (known ratio + known count).
+              Leaderboard based on card progress (explainable ratio + explainable count).
             </p>
           </div>
           <div className="rounded-lg border bg-white px-3 py-2 text-sm text-gray-600">
@@ -36,13 +36,13 @@ export default async function RankingPage() {
         <div className="mt-6 overflow-hidden rounded-xl border bg-white">
           <table className="min-w-full text-sm" aria-label="Knowledge leaderboard">
             <caption className="sr-only">
-              Knowledge leaderboard — ranked by known cards and known ratio
+              Knowledge leaderboard — ranked by explainable cards and explainable ratio
             </caption>
             <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
               <tr>
                 <th scope="col" className="px-4 py-3 font-semibold">Rank</th>
                 <th scope="col" className="px-4 py-3 font-semibold">User</th>
-                <th scope="col" className="px-4 py-3 font-semibold">Known</th>
+                <th scope="col" className="px-4 py-3 font-semibold">Explainable</th>
                 <th scope="col" className="hidden sm:table-cell px-4 py-3 font-semibold">Avg Score</th>
               </tr>
             </thead>
@@ -86,7 +86,7 @@ export default async function RankingPage() {
                           </span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-gray-900">{row.known}</td>
+                      <td className="px-4 py-3 text-gray-900">{row.explainable}</td>
                       <td className="hidden sm:table-cell px-4 py-3 text-gray-900">{(row.avgScore * 100).toFixed(1)}%</td>
                     </tr>
                   );

--- a/apps/web/src/app/saved/page.tsx
+++ b/apps/web/src/app/saved/page.tsx
@@ -5,6 +5,7 @@ import Navbar from '@/components/navbar';
 import Link from 'next/link';
 import { formatDomainLabel } from '@stem-brain/graph-engine';
 import ConfirmDeleteButton from '@/components/confirm-delete-button';
+import { getCardStatusShortLabel } from '@/lib/card-status';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,11 +54,11 @@ export default async function SavedPage({ searchParams }: SavedPageProps) {
       <div className="flex-grow w-full max-w-2xl mx-auto p-4 md:p-8">
         <div className="mb-6 flex items-end justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Saved Concepts</h1>
+            <h1 className="text-2xl font-bold text-gray-900">Review Queue</h1>
             <p className="text-sm text-gray-500">
               {hasActiveFilter
-                ? `${filteredCards.length} of ${savedCards.length} saved concepts`
-                : `${savedCards.length} concept${savedCards.length !== 1 ? 's' : ''} saved for review`}
+                ? `${filteredCards.length} of ${savedCards.length} review concepts`
+                : `${savedCards.length} concept${savedCards.length !== 1 ? 's' : ''} marked as still unclear`}
             </p>
           </div>
           <div className="flex gap-2">
@@ -80,7 +81,7 @@ export default async function SavedPage({ searchParams }: SavedPageProps) {
           </div>
         </div>
 
-        <form className="mb-4 rounded-lg border bg-white p-3 shadow-sm" role="search" aria-label="Filter saved concepts">
+        <form className="mb-4 rounded-lg border bg-white p-3 shadow-sm" role="search" aria-label="Filter review concepts">
           <div className="grid gap-2 md:grid-cols-[1fr_auto]">
             <label className="sr-only" htmlFor="saved-search">Search concepts</label>
             <input
@@ -121,8 +122,8 @@ export default async function SavedPage({ searchParams }: SavedPageProps) {
         {savedCards.length === 0 ? (
           <div className="rounded-xl border bg-white p-8 text-center shadow-sm">
             <p className="text-2xl mb-2" aria-hidden="true">📌</p>
-            <p className="font-semibold text-gray-800">No saved concepts yet</p>
-            <p className="text-sm text-gray-500 mt-1">Save concepts during practice to build your review queue.</p>
+            <p className="font-semibold text-gray-800">No review concepts yet</p>
+            <p className="text-sm text-gray-500 mt-1">Mark concepts as unclear during practice to build your review queue.</p>
             <Link href="/practice" className="mt-4 inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors">
               Start practicing
             </Link>
@@ -136,15 +137,15 @@ export default async function SavedPage({ searchParams }: SavedPageProps) {
             </Link>
           </div>
         ) : (
-          <ol className="grid gap-3 list-none p-0" aria-label="Saved concept cards">
+          <ol className="grid gap-3 list-none p-0" aria-label="Review concept cards">
             {filteredCards.map((card) => {
               const statusStyle = STATUS_STYLES[card.status] ?? STATUS_STYLES.saved;
               return (
                 <li key={card.id} className="bg-white border rounded-xl p-4 flex flex-col shadow-sm hover:shadow-md transition-shadow">
                   <div className="flex justify-between items-start gap-2 mb-2">
                     <h2 className="font-semibold text-gray-900 text-base leading-snug">{card.title}</h2>
-                    <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full capitalize border ${statusStyle}`}>
-                      {card.status}
+                    <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full border ${statusStyle}`}>
+                      {getCardStatusShortLabel(card.status)}
                     </span>
                   </div>
                   <p className="text-sm text-gray-600 mb-3 leading-relaxed">{card.summary}</p>
@@ -160,8 +161,8 @@ export default async function SavedPage({ searchParams }: SavedPageProps) {
                       >
                         <ConfirmDeleteButton
                           label="Remove"
-                          confirmMessage={`Remove "${card.title}" from saved?`}
-                          ariaLabel={`Remove "${card.title}" from saved`}
+                          confirmMessage={`Remove "${card.title}" from the review queue?`}
+                          ariaLabel={`Remove "${card.title}" from the review queue`}
                           className="rounded border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400"
                         />
                       </form>

--- a/apps/web/src/components/card-viewer.tsx
+++ b/apps/web/src/components/card-viewer.tsx
@@ -1,13 +1,21 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
-import { KnowledgeCard, saveCardState, getNextCard, CardStatus, getUserStats, type PrerequisiteInfo } from '@/actions/card-actions';
+import {
+  KnowledgeCard,
+  saveCardState,
+  getNextCard,
+  CardStatus,
+  getUserStats,
+  type PrerequisiteInfo,
+} from '@/actions/card-actions';
 import Card from './card';
 import Link from 'next/link';
+import { getCardStatusLabel } from '@/lib/card-status';
 
 interface CardViewerProps {
   initialCard: KnowledgeCard | null;
-  initialStats: { known: number; saved: number };
+  initialStats: { explainable: number; unclear: number };
   mode: 'new' | 'review';
   isGuest?: boolean;
   guestLimit?: number;
@@ -34,8 +42,8 @@ export default function CardViewer({
   const skippedIds = useRef<Set<string>>(new Set());
   // cards rated this round — excluded when fetching next card, cleared when all cards cycled
   const ratedIds = useRef<Set<string>>(new Set());
-  // review mode: snapshot of how many saved cards existed at session start
-  const initialReviewPool = useRef(initialStats.saved);
+  // review mode: snapshot of how many unclear cards existed at session start
+  const initialReviewPool = useRef(initialStats.unclear);
   // card-flip state: false = front only, true = answer revealed
   const [revealed, setRevealed] = useState(false);
   // undo state: shown after rating, cleared on undo/skip/next-rating
@@ -62,7 +70,7 @@ export default function CardViewer({
     setStats(initialStats);
     skippedIds.current.clear();
     ratedIds.current.clear();
-    initialReviewPool.current = initialStats.saved;
+    initialReviewPool.current = initialStats.unclear;
     setRevealed(false);
     setUndoVisible(false);
     keepRevealedOnBack.current = false;
@@ -246,7 +254,7 @@ export default function CardViewer({
       <div className="flex flex-col items-center justify-center px-6 py-16 text-center max-w-sm mx-auto bg-white border border-gray-100 rounded-2xl shadow-sm mt-4">
         <div className="mb-4 text-5xl" aria-hidden="true">🎉</div>
         <p className="text-xl font-bold text-gray-900">
-          {mode === 'review' ? "You're all caught up on learning queue items!" : "All caught up on new/unknown cards!"}
+          {mode === 'review' ? "You're all caught up on review queue items!" : "All caught up on new/unclear cards!"}
         </p>
         <p className="text-gray-500 mt-2 text-sm leading-relaxed">
           {isGuest && mode === 'new'
@@ -256,12 +264,12 @@ export default function CardViewer({
 
         <div className="mt-6 w-full grid grid-cols-2 gap-2 text-center">
           <div className="rounded-xl bg-emerald-50 border border-emerald-100 py-3">
-            <span className="block text-2xl font-bold text-emerald-700">{stats.known}</span>
-            <span className="text-xs text-emerald-600">Known</span>
+            <span className="block text-2xl font-bold text-emerald-700">{stats.explainable}</span>
+            <span className="text-xs text-emerald-600">Explainable</span>
           </div>
           <div className="rounded-xl bg-blue-50 border border-blue-100 py-3">
-            <span className="block text-2xl font-bold text-blue-600">{stats.saved}</span>
-            <span className="text-xs text-blue-500">Learning Queue</span>
+            <span className="block text-2xl font-bold text-blue-600">{stats.unclear}</span>
+            <span className="text-xs text-blue-500">Unclear</span>
           </div>
         </div>
 
@@ -284,7 +292,7 @@ export default function CardViewer({
             href="/saved"
             className="w-full rounded-xl border px-4 py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors text-center focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            View saved list
+            View review queue
           </Link>
           <Link
             href="/knowledge"
@@ -316,8 +324,8 @@ export default function CardViewer({
           /* ── Learn New: global stats, no bar ── */
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3 text-xs font-medium">
-              <span className="text-emerald-600">✓ {stats.known} known</span>
-              <span className="text-amber-600">🔖 {stats.saved} learning queue</span>
+              <span className="text-emerald-600">✓ {stats.explainable} explainable</span>
+              <span className="text-amber-600">◐ {stats.unclear} unclear</span>
             </div>
             <span className="text-xs text-gray-500" aria-live="polite">
               {reviewedCount > 0 ? `${reviewedCount} this session` : 'Learning new'}
@@ -380,7 +388,7 @@ export default function CardViewer({
       </div>
       {mode === 'new' && backNavigatedCardId === card.id && previousChoice && (
         <p className="mb-3 text-xs text-gray-500" aria-live="polite">
-          Previous choice on this card: <span className="font-semibold text-gray-700">{previousChoice === 'saved' ? 'Study' : 'Known'}</span>
+          Previous choice on this card: <span className="font-semibold text-gray-700">{getCardStatusLabel(previousChoice)}</span>
         </p>
       )}
 
@@ -397,7 +405,7 @@ export default function CardViewer({
             {card.prerequisites.map((prereq: PrerequisiteInfo) => (
               <span
                 key={prereq.id}
-                title={prereq.status === 'known' ? 'Known' : prereq.status === 'saved' ? 'In learning queue' : 'Not yet learned'}
+                title={prereq.status === 'known' ? 'Can explain' : prereq.status === 'saved' ? 'Still unclear' : 'Not yet learned'}
                 className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium border ${
                   prereq.status === 'known'
                     ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
@@ -407,7 +415,7 @@ export default function CardViewer({
                 }`}
               >
                 <span aria-hidden="true">
-                  {prereq.status === 'known' ? '✓' : prereq.status === 'saved' ? '🔖' : '○'}
+                  {prereq.status === 'known' ? '✓' : prereq.status === 'saved' ? '◐' : '○'}
                 </span>
                 {prereq.label}
               </span>
@@ -432,31 +440,31 @@ export default function CardViewer({
         {revealed ? 'Hide Answer ↑' : 'Show Answer ↓'}
       </button>
 
-      {/* ── AFTER reveal: Study | Known + Undo ── */}
+      {/* ── AFTER reveal: Unclear | Can Explain + Undo ── */}
       {revealed && (
         <>
           <div className="mt-3 flex w-full gap-3" role="group" aria-label="Rate this card">
-            {/* Study */}
+            {/* Unclear */}
             <button
               onClick={() => void handleAction('saved')}
               disabled={loading}
-              aria-label={mode === 'review' ? 'Keep in review list (shortcut: 2)' : 'Save to study later (shortcut: 2)'}
+              aria-label={mode === 'review' ? 'Still unclear on this concept (shortcut: 2)' : 'This concept is still unclear (shortcut: 2)'}
               className={`flex-1 flex flex-col items-center justify-center gap-1 py-5 text-amber-700 font-semibold rounded-2xl transition-colors disabled:opacity-50 border active:scale-95 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 ${
                 previousChoice === 'saved'
                   ? 'bg-amber-100 border-amber-400 ring-2 ring-amber-300'
                   : 'bg-amber-50 hover:bg-amber-100 border-amber-200'
               }`}
             >
-              <span className="text-xl">{mode === 'review' ? '📌' : '🔖'}</span>
-              <span className="text-sm font-bold">{mode === 'review' ? 'Keep' : 'Study'}</span>
-              <span className="text-[10px] font-normal opacity-60">{mode === 'review' ? 'still learning' : 'need more review'}</span>
+              <span className="text-xl">◐</span>
+              <span className="text-sm font-bold">Unclear</span>
+              <span className="text-[10px] font-normal opacity-60">{mode === 'review' ? 'still needs review' : 'not stable yet'}</span>
             </button>
 
-            {/* Known */}
+            {/* Can Explain */}
             <button
               onClick={() => void handleAction('known')}
               disabled={loading}
-              aria-label="Mark as known (shortcut: 1)"
+              aria-label="Mark as can explain (shortcut: 1)"
               className={`flex-1 flex flex-col items-center justify-center gap-1 py-5 text-emerald-700 font-semibold rounded-2xl transition-colors disabled:opacity-50 border active:scale-95 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
                 previousChoice === 'known'
                   ? 'bg-emerald-100 border-emerald-400 ring-2 ring-emerald-300'
@@ -464,8 +472,8 @@ export default function CardViewer({
               }`}
             >
               <span className="text-xl">✓</span>
-              <span className="text-sm font-bold">{mode === 'review' ? 'Got it!' : 'Known'}</span>
-              <span className="text-[10px] font-normal opacity-60">{mode === 'review' ? 'nailed it' : 'recalled it'}</span>
+              <span className="text-sm font-bold">Can Explain</span>
+              <span className="text-[10px] font-normal opacity-60">{mode === 'review' ? 'feels solid now' : 'self-reported strong'}</span>
             </button>
           </div>
 
@@ -486,12 +494,12 @@ export default function CardViewer({
       {/* Action hint */}
       <p className="mt-1 text-xs text-gray-400 text-center">
         <span className="sm:hidden">
-          {!revealed ? 'Tap "Show Answer" to reveal' : 'Tap Study or Known to rate'}
+          {!revealed ? 'Tap "Show Answer" to reveal' : 'Tap Unclear or Can Explain to rate'}
         </span>
         <span className="hidden sm:inline">
           {!revealed
             ? <><kbd className="font-mono">Space</kbd> or <kbd className="font-mono">Enter</kbd> to reveal · <kbd className="font-mono">→</kbd> skip</>
-            : <><kbd className="font-mono">1</kbd> known · <kbd className="font-mono">2</kbd> study · {undoVisible && <><kbd className="font-mono">Z</kbd> undo · </>}<kbd className="font-mono">←</kbd> back · <kbd className="font-mono">→</kbd> skip</>
+            : <><kbd className="font-mono">1</kbd> can explain · <kbd className="font-mono">2</kbd> unclear · {undoVisible && <><kbd className="font-mono">Z</kbd> undo · </>}<kbd className="font-mono">←</kbd> back · <kbd className="font-mono">→</kbd> skip</>
           }
         </span>
       </p>

--- a/apps/web/src/components/home-graph-scene.tsx
+++ b/apps/web/src/components/home-graph-scene.tsx
@@ -10,21 +10,21 @@ const ForceGraph3D = dynamic(() => import('react-force-graph-3d'), {
 }) as any;
 
 type HomeGraphSceneProps = {
-  known: number;
-  saved: number;
+  explainable: number;
+  unclear: number;
   notes: number;
 };
 
 const NODE_GROUPS = {
-  known: { color: '#2dd4bf', hotColor: '#99f6e4', label: 'Known' },
-  saved: { color: '#60a5fa', hotColor: '#bfdbfe', label: 'Saved' },
-  notes: { color: '#fbbf24', hotColor: '#fde68a', label: 'Notes' },
+  explainable: { color: '#22c55e', hotColor: '#86efac', label: 'Explainable' },
+  unclear: { color: '#38bdf8', hotColor: '#7dd3fc', label: 'Unclear' },
+  notes: { color: '#f59e0b', hotColor: '#fcd34d', label: 'Notes' },
   core: { color: '#94a3b8', label: 'Concepts' },
 };
 
-type ActiveGroup = keyof Pick<typeof NODE_GROUPS, 'known' | 'saved' | 'notes'>;
+type ActiveGroup = keyof Pick<typeof NODE_GROUPS, 'explainable' | 'unclear' | 'notes'>;
 
-const GROUP_SEQUENCE: ActiveGroup[] = ['known', 'saved', 'notes'];
+const GROUP_SEQUENCE: ActiveGroup[] = ['explainable', 'unclear', 'notes'];
 
 const TOPICS = [
   'Cell Signaling',
@@ -57,12 +57,12 @@ const TOPICS = [
   'VLSI Design',
 ];
 
-export default function HomeGraphScene({ known, saved, notes }: HomeGraphSceneProps) {
+export default function HomeGraphScene({ explainable, unclear, notes }: HomeGraphSceneProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const graphContainerRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<any>(null);
   const [dimensions, setDimensions] = useState({ width: 720, height: 560 });
-  const [activeGroup, setActiveGroup] = useState<ActiveGroup>('known');
+  const [activeGroup, setActiveGroup] = useState<ActiveGroup>('explainable');
 
   useEffect(() => {
     const element = graphContainerRef.current;
@@ -98,7 +98,7 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
     if (!controls) return;
 
     controls.autoRotate = true;
-    controls.autoRotateSpeed = activeGroup === 'saved' ? 0.78 : activeGroup === 'notes' ? 0.42 : 0.6;
+    controls.autoRotateSpeed = activeGroup === 'unclear' ? 0.78 : activeGroup === 'notes' ? 0.42 : 0.6;
     controls.enablePan = false;
     controls.minDistance = 90;
     controls.maxDistance = 430;
@@ -120,8 +120,8 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
   }, []);
 
   const graphData = useMemo(() => {
-    const knownCount = Math.min(9, Math.max(3, Math.ceil(known / 2)));
-    const savedCount = Math.min(7, Math.max(3, Math.ceil(saved / 2)));
+    const explainableCount = Math.min(9, Math.max(3, Math.ceil(explainable / 2)));
+    const unclearCount = Math.min(7, Math.max(3, Math.ceil(unclear / 2)));
     const noteCount = Math.min(6, Math.max(2, notes));
     const coreCount = 12;
 
@@ -136,8 +136,8 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
     ];
 
     const groups = [
-      { key: 'known', count: knownCount, start: 0, val: 7 },
-      { key: 'saved', count: savedCount, start: 6, val: 6 },
+      { key: 'explainable', count: explainableCount, start: 0, val: 7 },
+      { key: 'unclear', count: unclearCount, start: 6, val: 6 },
       { key: 'notes', count: noteCount, start: 11, val: 5 },
       { key: 'core', count: coreCount, start: 3, val: 4 },
     ] as const;
@@ -183,7 +183,7 @@ export default function HomeGraphScene({ known, saved, notes }: HomeGraphScenePr
     }
 
     return { nodes, links };
-  }, [activeGroup, known, saved, notes]);
+  }, [activeGroup, explainable, unclear, notes]);
 
   return (
     <div

--- a/apps/web/src/components/knowledge-graph-3d.tsx
+++ b/apps/web/src/components/knowledge-graph-3d.tsx
@@ -243,9 +243,9 @@ export default function KnowledgeGraph3D({ cards, onClose }: Props) {
         <p className="text-[10px] uppercase tracking-widest text-gray-500 mb-3 font-semibold">Status</p>
         <div className="space-y-2">
           {[
-            { label: 'Known', color: STATUS_COLORS.known },
-            { label: 'Saved', color: STATUS_COLORS.saved },
-            { label: 'Review', color: STATUS_COLORS.unknown },
+            { label: 'Explainable', color: STATUS_COLORS.known },
+            { label: 'Unclear', color: STATUS_COLORS.saved },
+            { label: 'Not Started', color: STATUS_COLORS.unknown },
             { label: 'Unseen', color: STATUS_COLORS.unseen },
           ].map((item) => (
             <div key={item.label} className="flex items-center gap-2.5">

--- a/apps/web/src/components/knowledge-map.tsx
+++ b/apps/web/src/components/knowledge-map.tsx
@@ -5,6 +5,7 @@ import { getAllCardsWithStatus, type KnowledgeCard, type CardStatus } from '@/ac
 import KnowledgeGraph3D from './knowledge-graph-3d';
 import { getCardLevelMeta } from '@stem-brain/graph-engine';
 import { formatDomainLabel } from '@stem-brain/graph-engine';
+import { getCardStatusShortLabel } from '@/lib/card-status';
 
 type Props = {
   initialCards: (KnowledgeCard & { status: CardStatus | null })[];
@@ -140,8 +141,8 @@ export default function KnowledgeMap({ initialCards }: Props) {
                 className="p-2 border rounded bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
               >
                 <option value="all">All Status</option>
-                <option value="known">Known</option>
-                <option value="saved">Saved</option>
+                <option value="known">Can Explain</option>
+                <option value="saved">Unclear</option>
                 <option value="unstarted">Not Started</option>
               </select>
               
@@ -177,8 +178,8 @@ export default function KnowledgeMap({ initialCards }: Props) {
             <div>
               <span className="mb-1.5 block font-semibold text-gray-500 uppercase tracking-wide">Status</span>
               <div className="flex flex-wrap gap-2">
-                <span className="flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-full bg-green-300 border border-green-400"></span>Known</span>
-                <span className="flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-full bg-blue-300 border border-blue-400"></span>Saved</span>
+                <span className="flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-full bg-green-300 border border-green-400"></span>Can Explain</span>
+                <span className="flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-full bg-blue-300 border border-blue-400"></span>Unclear</span>
                 <span className="flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-full bg-gray-200 border border-gray-300"></span>Not Started</span>
               </div>
             </div>
@@ -222,11 +223,7 @@ function KnowledgeCardItem({ card }: { card: KnowledgeCard & { status: CardStatu
   };
 
   const getStatusLabel = (status: CardStatus | null) => {
-    switch (status) {
-      case 'known': return 'Known';
-      case 'saved': return 'Saved';
-      default: return 'Not Started';
-    }
+    return getCardStatusShortLabel(status);
   };
 
   return (

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 
 const NAV_ITEMS = [
   { href: '/practice', label: 'Practice' },
-  { href: '/saved', label: 'Saved' },
+  { href: '/saved', label: 'Review Queue' },
   { href: '/knowledge', label: 'Knowledge Map' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/my-knowledge', label: 'My Knowledge' },

--- a/apps/web/src/components/reset-button.tsx
+++ b/apps/web/src/components/reset-button.tsx
@@ -10,7 +10,7 @@ export default function ResetButton({ resetAction }: ResetButtonProps) {
   const [isPending, startTransition] = useTransition();
 
   const handleClick = () => {
-    if (!window.confirm('Reset all progress? This will clear your known / saved history and cannot be undone.')) {
+    if (!window.confirm('Reset all progress? This will clear your explainable / unclear history and cannot be undone.')) {
       return;
     }
     startTransition(() => {

--- a/apps/web/src/lib/card-status.ts
+++ b/apps/web/src/lib/card-status.ts
@@ -1,0 +1,13 @@
+import type { CardStatus } from '@/actions/card-actions';
+
+export function getCardStatusLabel(status: CardStatus | null) {
+  if (status === 'known') return 'Can Explain';
+  if (status === 'saved') return 'Unclear';
+  return 'Not Started';
+}
+
+export function getCardStatusShortLabel(status: CardStatus | null) {
+  if (status === 'known') return 'Explainable';
+  if (status === 'saved') return 'Reviewing';
+  return 'Not Started';
+}

--- a/apps/web/src/lib/knowledge-graph-db.ts
+++ b/apps/web/src/lib/knowledge-graph-db.ts
@@ -1,0 +1,599 @@
+import pool from '@/lib/db';
+import { GRAPH_EDGES, GRAPH_NODES } from '@stem-brain/graph-engine';
+import {
+  getGraphDataForUser,
+  processQuizResult,
+  propagateQuizResult,
+  runDiffusion,
+  runGlobalDiffusion,
+} from '@stem-brain/graph-engine';
+import type {
+  ForceGraphData,
+  GraphEdge,
+  GraphNode,
+  GraphNodeWithKnowledge,
+  KnowledgeLevel,
+  UserKnowledgeState,
+} from '@stem-brain/graph-engine';
+
+type GraphNodeRow = {
+  id: string;
+  label: string;
+  domain: string;
+  level: number;
+  difficulty: number;
+  type: GraphNode['type'];
+};
+
+type GraphEdgeRow = {
+  source: string;
+  target: string;
+  type: GraphEdge['type'];
+  weight: number;
+};
+
+type UserKnowledgeStateRow = {
+  user_id: string;
+  node_id: string;
+  knowledge_state: number;
+  confidence: number;
+  last_updated: string;
+  first_known_at: string | null;
+};
+
+type ProfileCardStateRow = {
+  node_id: string;
+  title: string;
+  summary: string | null;
+  status: string | null;
+  progress_state: string | null;
+  last_seen: string | null;
+};
+
+type DomainSummary = {
+  total: number;
+  mastered: number;
+  reinforcing: number;
+  not_started: number;
+  avg: number;
+};
+
+type KnowledgeProfileNode = {
+  id: string;
+  label: string;
+  domain: string;
+  level: number;
+  difficulty: number;
+  type: GraphNode['type'];
+  knowledge_state: KnowledgeLevel;
+  confidence: number;
+  first_known_at?: string;
+  last_updated?: string;
+  prerequisite_ids: string[];
+  dependent_ids: string[];
+};
+
+export type KnowledgeProfile = {
+  user_id: string;
+  generated_at: string;
+  summary: {
+    total_nodes: number;
+    mastered: number;
+    reinforcing: number;
+    not_started: number;
+    avg_knowledge: number;
+  };
+  domains: Record<string, DomainSummary>;
+  focus: {
+    weak_foundations: KnowledgeProfileNode[];
+    ready_to_learn: KnowledgeProfileNode[];
+    strongest_concepts: KnowledgeProfileNode[];
+  };
+  nodes: KnowledgeProfileNode[];
+  card_states: Array<{
+    node_id: string;
+    title: string;
+    summary: string | null;
+    status: string | null;
+    progress_state: string | null;
+    last_seen: string | null;
+  }>;
+};
+
+export type KnowledgeContextExport = {
+  generated_at: string;
+  summary: string;
+  prompt_block: string;
+};
+
+function ensureGraphDatabase() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('Graph database access requires DATABASE_URL to be configured.');
+  }
+}
+
+function toKnowledgeLevel(value: number): KnowledgeLevel {
+  if (value >= 0.75) return 1;
+  if (value >= 0.25) return 0.5;
+  return 0;
+}
+
+function toRenderKnowledge(state: UserKnowledgeState | undefined): number {
+  if (!state) return 0;
+  if (state.knowledge_state === 1) return Math.min(1, 0.85 + state.confidence * 0.15);
+  if (state.knowledge_state === 0.5) return 0.35 + state.confidence * 0.3;
+  return state.confidence * 0.15;
+}
+
+function asUserKnowledgeState(row: UserKnowledgeStateRow): UserKnowledgeState {
+  return {
+    user_id: row.user_id,
+    node_id: row.node_id,
+    knowledge_state: row.knowledge_state as KnowledgeLevel,
+    confidence: row.confidence,
+    last_updated: row.last_updated,
+    first_known_at: row.first_known_at ?? undefined,
+  };
+}
+
+async function getGraphNodes(): Promise<GraphNode[]> {
+  if (!process.env.DATABASE_URL) return [...GRAPH_NODES];
+  ensureGraphDatabase();
+  const { rows } = await pool.query<GraphNodeRow>(
+    'SELECT id, label, domain, level, difficulty, type FROM graph_nodes ORDER BY domain, level, label'
+  );
+  return rows;
+}
+
+async function getGraphEdges(): Promise<GraphEdge[]> {
+  if (!process.env.DATABASE_URL) return [...GRAPH_EDGES];
+  ensureGraphDatabase();
+  const { rows } = await pool.query<GraphEdgeRow>(
+    'SELECT source, target, type, weight FROM graph_edges ORDER BY source, target, type'
+  );
+  return rows;
+}
+
+async function getUserStateMap(userId: string): Promise<Map<string, UserKnowledgeState>> {
+  if (!process.env.DATABASE_URL) return new Map();
+  ensureGraphDatabase();
+  const { rows } = await pool.query<UserKnowledgeStateRow>(
+    `SELECT user_id, node_id, knowledge_state, confidence, last_updated, first_known_at
+     FROM user_knowledge_states
+     WHERE user_id = $1`,
+    [userId]
+  );
+  return new Map(rows.map((row) => [row.node_id, asUserKnowledgeState(row)]));
+}
+
+async function persistUserStates(userId: string, states: UserKnowledgeState[]): Promise<void> {
+  if (states.length === 0) return;
+  ensureGraphDatabase();
+
+  const values: unknown[] = [];
+  const tuples: string[] = [];
+
+  for (const state of states) {
+    const base = values.length;
+    tuples.push(
+      `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`
+    );
+    values.push(
+      userId,
+      state.node_id,
+      state.knowledge_state,
+      state.confidence,
+      state.last_updated,
+      state.first_known_at ?? null
+    );
+  }
+
+  await pool.query(
+    `
+    INSERT INTO user_knowledge_states (
+      user_id,
+      node_id,
+      knowledge_state,
+      confidence,
+      last_updated,
+      first_known_at
+    )
+    VALUES ${tuples.join(',\n')}
+    ON CONFLICT (user_id, node_id)
+    DO UPDATE SET
+      knowledge_state = EXCLUDED.knowledge_state,
+      confidence = EXCLUDED.confidence,
+      last_updated = EXCLUDED.last_updated,
+      first_known_at = CASE
+        WHEN EXCLUDED.knowledge_state = 1
+          THEN COALESCE(user_knowledge_states.first_known_at, EXCLUDED.first_known_at, EXCLUDED.last_updated)
+        ELSE user_knowledge_states.first_known_at
+      END
+    `,
+    values
+  );
+}
+
+export async function getDbGraphDataForUser(userId: string): Promise<ForceGraphData> {
+  const [nodes, edges, states] = await Promise.all([
+    getGraphNodes(),
+    getGraphEdges(),
+    getUserStateMap(userId),
+  ]);
+  const now = Date.now();
+
+  const nodesWithKnowledge: GraphNodeWithKnowledge[] = nodes.map((node) => {
+    const state = states.get(node.id);
+    const knowledge = toRenderKnowledge(state);
+    const confidence = state?.confidence ?? 0;
+    const firstKnownAt = state?.first_known_at ? new Date(state.first_known_at).getTime() : null;
+
+    let growth_daily = 0;
+    let growth_weekly = 0;
+    let growth_monthly = 0;
+
+    if (firstKnownAt) {
+      const ageMs = now - firstKnownAt;
+      const day = 86400000;
+      if (ageMs < day) growth_daily = knowledge;
+      if (ageMs < 7 * day) growth_weekly = knowledge;
+      if (ageMs < 30 * day) growth_monthly = knowledge;
+    }
+
+    return {
+      ...node,
+      knowledge,
+      confidence,
+      growth_daily,
+      growth_weekly,
+      growth_monthly,
+    };
+  });
+
+  return {
+    nodes: nodesWithKnowledge,
+    links: edges,
+  };
+}
+
+export async function getDbUserGraphStats(userId: string): Promise<{
+  total_nodes: number;
+  mastered: number;
+  reinforcing: number;
+  not_started: number;
+  avg_knowledge: number;
+  domains: Record<string, DomainSummary>;
+}> {
+  const [nodes, states] = await Promise.all([getGraphNodes(), getUserStateMap(userId)]);
+
+  let mastered = 0;
+  let reinforcing = 0;
+  let totalK = 0;
+  const domains: Record<string, { total: number; mastered: number; reinforcing: number; sumK: number }> = {};
+
+  for (const node of nodes) {
+    const state = states.get(node.id);
+    const k = state?.knowledge_state ?? 0;
+    totalK += k;
+    if (k === 1) mastered += 1;
+    else if (k === 0.5) reinforcing += 1;
+
+    if (!domains[node.domain]) {
+      domains[node.domain] = { total: 0, mastered: 0, reinforcing: 0, sumK: 0 };
+    }
+    domains[node.domain].total += 1;
+    domains[node.domain].sumK += k;
+    if (k === 1) domains[node.domain].mastered += 1;
+    if (k === 0.5) domains[node.domain].reinforcing += 1;
+  }
+
+  const totalNodes = nodes.length;
+  const notStarted = totalNodes - mastered - reinforcing;
+
+  return {
+    total_nodes: totalNodes,
+    mastered,
+    reinforcing,
+    not_started: notStarted,
+    avg_knowledge: totalNodes > 0 ? totalK / totalNodes : 0,
+    domains: Object.fromEntries(
+      Object.entries(domains).map(([domain, stats]) => [
+        domain,
+        {
+          total: stats.total,
+          mastered: stats.mastered,
+          reinforcing: stats.reinforcing,
+          not_started: stats.total - stats.mastered - stats.reinforcing,
+          avg: stats.total > 0 ? stats.sumK / stats.total : 0,
+        },
+      ])
+    ),
+  };
+}
+
+export async function getDbNodeKnowledge(
+  userId: string,
+  nodeId: string
+): Promise<{ knowledge: number; confidence: number } | null> {
+  const states = await getUserStateMap(userId);
+  const state = states.get(nodeId);
+  if (!state) return { knowledge: 0, confidence: 0 };
+  return {
+    knowledge: state.knowledge_state,
+    confidence: state.confidence,
+  };
+}
+
+export async function submitDbQuizResult(
+  userId: string,
+  nodeId: string,
+  result: 0 | 0.5 | 1
+): Promise<{
+  success: boolean;
+  node: GraphNodeWithKnowledge | null;
+  propagated_count: number;
+}> {
+  if (!process.env.DATABASE_URL) {
+    const { propagatedUpdates } = processQuizResult(userId, nodeId, result);
+    runGlobalDiffusion(userId, 0.3);
+    const graphData = getGraphDataForUser(userId);
+
+    return {
+      success: true,
+      node: graphData.nodes.find((node) => node.id === nodeId) ?? null,
+      propagated_count: Math.max(0, propagatedUpdates.size - 1),
+    };
+  }
+
+  ensureGraphDatabase();
+
+  const [nodes, edges, states] = await Promise.all([
+    getGraphNodes(),
+    getGraphEdges(),
+    getUserStateMap(userId),
+  ]);
+
+  const now = new Date().toISOString();
+  const existingState = states.get(nodeId);
+  const currentConfidence = existingState?.confidence ?? 0;
+  const newConfidence =
+    result === 1
+      ? Math.min(1, currentConfidence + 0.15)
+      : result === 0.5
+        ? Math.max(0.3, currentConfidence)
+        : Math.max(0, currentConfidence - 0.1);
+
+  const directUpdate: UserKnowledgeState = {
+    user_id: userId,
+    node_id: nodeId,
+    knowledge_state: result,
+    confidence: newConfidence,
+    last_updated: now,
+    first_known_at:
+      result === 1 ? existingState?.first_known_at ?? now : existingState?.first_known_at,
+  };
+  states.set(nodeId, directUpdate);
+
+  const propagatedUpdates = propagateQuizResult(nodes, edges, states, nodeId, result);
+  for (const [nextNodeId, nextKnowledge] of propagatedUpdates) {
+    if (nextNodeId === nodeId) continue;
+    const existing = states.get(nextNodeId);
+    states.set(nextNodeId, {
+      user_id: userId,
+      node_id: nextNodeId,
+      knowledge_state: toKnowledgeLevel(nextKnowledge),
+      confidence: existing?.confidence ?? 0.2,
+      last_updated: now,
+      first_known_at:
+        toKnowledgeLevel(nextKnowledge) === 1
+          ? existing?.first_known_at ?? now
+          : existing?.first_known_at,
+    });
+  }
+
+  const diffused = runDiffusion({
+    nodes,
+    edges,
+    knowledgeStates: states,
+    alpha: 0.3,
+  });
+
+  for (const [nextNodeId, nextKnowledge] of diffused.updatedStates) {
+    const existing = states.get(nextNodeId);
+    if (!existing) continue;
+    const nextLevel = toKnowledgeLevel(nextKnowledge);
+    states.set(nextNodeId, {
+      ...existing,
+      knowledge_state: nextLevel,
+      last_updated: now,
+      first_known_at: nextLevel === 1 ? existing.first_known_at ?? now : existing.first_known_at,
+    });
+  }
+
+  await persistUserStates(userId, [...states.values()]);
+  const graphData = await getDbGraphDataForUser(userId);
+
+  return {
+    success: true,
+    node: graphData.nodes.find((node) => node.id === nodeId) ?? null,
+    propagated_count: Math.max(0, propagatedUpdates.size - 1),
+  };
+}
+
+export async function buildKnowledgeProfile(userId: string): Promise<KnowledgeProfile> {
+  const [nodes, edges, states, summary] = await Promise.all([
+    getGraphNodes(),
+    getGraphEdges(),
+    getUserStateMap(userId),
+    getDbUserGraphStats(userId),
+  ]);
+
+  const prereqByTarget = new Map<string, string[]>();
+  const dependentBySource = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (edge.type !== 'prerequisite') continue;
+    const prereqs = prereqByTarget.get(edge.target) ?? [];
+    prereqs.push(edge.source);
+    prereqByTarget.set(edge.target, prereqs);
+
+    const dependents = dependentBySource.get(edge.source) ?? [];
+    dependents.push(edge.target);
+    dependentBySource.set(edge.source, dependents);
+  }
+
+  const profileNodes: KnowledgeProfileNode[] = nodes.map((node) => {
+    const state = states.get(node.id);
+    return {
+      id: node.id,
+      label: node.label,
+      domain: node.domain,
+      level: node.level,
+      difficulty: node.difficulty,
+      type: node.type,
+      knowledge_state: state?.knowledge_state ?? 0,
+      confidence: state?.confidence ?? 0,
+      first_known_at: state?.first_known_at,
+      last_updated: state?.last_updated,
+      prerequisite_ids: prereqByTarget.get(node.id) ?? [],
+      dependent_ids: dependentBySource.get(node.id) ?? [],
+    };
+  });
+
+  const weakFoundations = profileNodes
+    .filter((node) => node.level <= 2 && node.knowledge_state < 1)
+    .sort((a, b) => {
+      const dependentGap = b.dependent_ids.length - a.dependent_ids.length;
+      if (dependentGap !== 0) return dependentGap;
+      return a.knowledge_state - b.knowledge_state;
+    })
+    .slice(0, 12);
+
+  const readyToLearn = profileNodes
+    .filter((node) => node.knowledge_state < 1)
+    .filter((node) => {
+      if (node.prerequisite_ids.length === 0) return false;
+      return node.prerequisite_ids.every((prereqId) => {
+        const prereq = states.get(prereqId);
+        return (prereq?.knowledge_state ?? 0) >= 0.5;
+      });
+    })
+    .sort((a, b) => {
+      if (a.level !== b.level) return a.level - b.level;
+      return b.confidence - a.confidence;
+    })
+    .slice(0, 12);
+
+  const strongestConcepts = profileNodes
+    .filter((node) => node.knowledge_state === 1)
+    .sort((a, b) => {
+      if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+      return b.dependent_ids.length - a.dependent_ids.length;
+    })
+    .slice(0, 12);
+
+  const { rows: cardRows } = process.env.DATABASE_URL
+    ? await pool.query<ProfileCardStateRow>(
+        `
+        SELECT
+          REPLACE(kc.id, 'graph_', '') AS node_id,
+          kc.title,
+          kc.summary,
+          ucs.status,
+          ucs.progress_state,
+          ucs.last_seen::text AS last_seen
+        FROM knowledge_cards kc
+        LEFT JOIN user_card_states ucs
+          ON kc.id = ucs.card_id AND ucs.user_id = $1
+        WHERE kc.id NOT LIKE 'drill_%'
+        ORDER BY kc.domain, kc.level, kc.title
+        `,
+        [userId]
+      )
+    : { rows: [] as ProfileCardStateRow[] };
+
+  return {
+    user_id: userId,
+    generated_at: new Date().toISOString(),
+    summary: {
+      total_nodes: summary.total_nodes,
+      mastered: summary.mastered,
+      reinforcing: summary.reinforcing,
+      not_started: summary.not_started,
+      avg_knowledge: summary.avg_knowledge,
+    },
+    domains: summary.domains,
+    focus: {
+      weak_foundations: weakFoundations,
+      ready_to_learn: readyToLearn,
+      strongest_concepts: strongestConcepts,
+    },
+    nodes: profileNodes,
+    card_states: cardRows,
+  };
+}
+
+export async function buildKnowledgeContext(userId: string): Promise<KnowledgeContextExport> {
+  const profile = await buildKnowledgeProfile(userId);
+
+  const listToLine = (label: string, nodes: KnowledgeProfileNode[]) =>
+    `${label}: ${
+      nodes.length > 0
+        ? nodes.map((node) => `${node.label} [${node.knowledge_state}, c=${node.confidence.toFixed(2)}]`).join('; ')
+        : 'none'
+    }`;
+
+  const domainLine = Object.entries(profile.domains)
+    .sort((a, b) => b[1].avg - a[1].avg)
+    .map(([domain, stats]) => `${domain}: avg=${stats.avg.toFixed(2)}, mastered=${stats.mastered}, reinforcing=${stats.reinforcing}, not_started=${stats.not_started}`)
+    .join(' | ');
+
+  const summary = [
+    `User knowledge summary: ${profile.summary.mastered} mastered, ${profile.summary.reinforcing} reinforcing, ${profile.summary.not_started} not_started out of ${profile.summary.total_nodes} nodes.`,
+    `Domain strengths: ${domainLine || 'none'}.`,
+    listToLine('Strongest concepts', profile.focus.strongest_concepts),
+    listToLine('Weak foundations', profile.focus.weak_foundations),
+    listToLine('Ready to learn next', profile.focus.ready_to_learn),
+  ].join(' ');
+
+  const promptBlock = [
+    'Use this user knowledge map to adapt explanation depth and examples.',
+    'Prefer short reminders for mastered concepts, compact refreshers for reinforcing concepts, and first-principles explanations for not_started concepts.',
+    'Do not assume mastery outside the strongest concepts listed below.',
+    `Mastery summary: ${profile.summary.mastered}/${profile.summary.total_nodes} nodes mastered, ${profile.summary.reinforcing} reinforcing.`,
+    listToLine('Strongest concepts', profile.focus.strongest_concepts),
+    listToLine('Weak foundations', profile.focus.weak_foundations),
+    listToLine('Ready to learn next', profile.focus.ready_to_learn),
+  ].join('\n');
+
+  return {
+    generated_at: profile.generated_at,
+    summary,
+    prompt_block: promptBlock,
+  };
+}
+
+export function getStaticGraphSummary() {
+  const nodes = [...GRAPH_NODES];
+  const edges = [...GRAPH_EDGES];
+  const domains = [...new Set(nodes.map((node) => node.domain))];
+
+  return {
+    total_nodes: nodes.length,
+    total_edges: edges.length,
+    domains: domains.length,
+    domain_list: domains,
+    level_distribution: {
+      0: nodes.filter((node) => node.level === 0).length,
+      1: nodes.filter((node) => node.level === 1).length,
+      2: nodes.filter((node) => node.level === 2).length,
+    },
+  };
+}
+
+export function getLeaderboardFromStates(rows: Array<{ user_id: string; avg_knowledge: number; known: number }>) {
+  return rows.map((entry) => ({
+    userId: entry.user_id,
+    mastered: entry.known,
+    avgScore: entry.avg_knowledge,
+  }));
+}


### PR DESCRIPTION
## Summary
- Persist graph knowledge state in Postgres-backed actions and API routes while keeping no-DB fallback quiz behavior.
- Add self-report/evidence schema fields and a user_knowledge_evidence migration for richer knowledge modeling.
- Add knowledge-profile and knowledge-context API exports for tooling/AI context.
- Update web copy from known/saved toward explainable/unclear/review queue language without reverting the current homepage scene.

## Code review notes
- Fixed schema.sql to keep Clerk user IDs as text for user_card_states and user_knowledge_states.
- Fixed fallback mode so /api/quiz_result still works without DATABASE_URL by using the existing in-memory graph engine path.
- Built this PR from origin/main to avoid carrying stale local homepage asset deletions.

## Verification
- pnpm --filter @stem-brain/web lint
- pnpm --filter @stem-brain/web typecheck
- pnpm --filter @stem-brain/web build

## Follow-up
- Apply apps/web/drizzle/migrations/0003_add_knowledge_evidence_layer.sql in the target database before relying on persisted evidence fields.
- Existing Drizzle migration metadata was already partial in this repo; this PR follows the current hand-authored migration pattern rather than rewriting migration history.