### PR TITLE
Allow limited guest practice

### DIFF
--- a/apps/web/src/actions/card-actions.ts
+++ b/apps/web/src/actions/card-actions.ts
@@ -2,7 +2,8 @@
 
 import pool from '@/lib/db';
 import { revalidatePath } from 'next/cache';
-import { requireCurrentUser } from '@/lib/auth';
+import { requireCurrentActor } from '@/lib/auth';
+import { GUEST_PRACTICE_CARD_LIMIT } from '@/lib/guest';
 import { GRAPH_EDGES } from '@stem-brain/graph-engine';
 import { GRAPH_NODES } from '@stem-brain/graph-engine';
 import { CARD_CONTENT } from '@stem-brain/graph-engine';
@@ -280,6 +281,7 @@ function generateDrillCards(count: number, startIndex: number): KnowledgeCard[] 
 }
 
 const MOCK_CARDS: KnowledgeCard[] = [...CORE_CARDS].slice(0, TARGET_CARD_COUNT);
+const GUEST_CARD_IDS = new Set(MOCK_CARDS.slice(0, GUEST_PRACTICE_CARD_LIMIT).map((card) => card.id));
 
 const NODE_BY_ID = new Map(GRAPH_NODES.map((node) => [node.id, node]));
 const CARDS_BY_ID = new Map(MOCK_CARDS.map((card) => [card.id, card]));
@@ -296,6 +298,11 @@ function withRelatedConcepts<T extends { id: string; related_concepts?: string[]
   const related = CARDS_BY_ID.get(card.id)?.related_concepts;
   if (!related || related.length === 0) return card;
   return { ...card, related_concepts: related };
+}
+
+function limitCardsForGuest<T extends { id: string }>(cards: T[], isGuest: boolean) {
+  if (!isGuest) return cards;
+  return cards.filter((card) => GUEST_CARD_IDS.has(card.id));
 }
 
 for (const edge of GRAPH_EDGES) {
@@ -583,7 +590,7 @@ function getRecallCue(card: KnowledgeCard | undefined, fallbackTitle: string): s
 }
 
 export async function generateQuizForNode(nodeId: string): Promise<NodeQuiz> {
-  await requireCurrentUser();
+  await requireCurrentActor();
 
   const normalizedNodeId = normalizeGraphNodeId(nodeId);
   const node = NODE_BY_ID.get(normalizedNodeId);
@@ -629,11 +636,11 @@ export async function generateQuizForNode(nodeId: string): Promise<NodeQuiz> {
 }
 
 export async function getNextCard(mode: 'new' | 'review' = 'new', excludeIds?: string[]) {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   const excluded = new Set(excludeIds ?? []);
 
   if (!process.env.DATABASE_URL) {
-    const mockRows: CardWithStatusRow[] = MOCK_CARDS
+    const mockRows: CardWithStatusRow[] = limitCardsForGuest(MOCK_CARDS, user.isGuest)
       .filter((card) => !excluded.has(card.id))
       .map((card) => ({
         ...card,
@@ -678,7 +685,7 @@ export async function getNextCard(mode: 'new' | 'review' = 'new', excludeIds?: s
     }
 
     const res = await pool.query(query, [user.id]);
-    const rowsWithRelated = (res.rows as CardWithStatusRow[])
+    const rowsWithRelated = limitCardsForGuest(res.rows as CardWithStatusRow[], user.isGuest)
       .map((row) => ({
         ...row,
         status: deriveLegacyStatus(row),
@@ -699,7 +706,7 @@ export async function getNextCard(mode: 'new' | 'review' = 'new', excludeIds?: s
     await ensureMoreGeneratedCards(1);
 
     const retryRes = await pool.query(query, [user.id]);
-    const retryRowsWithRelated = (retryRes.rows as CardWithStatusRow[])
+    const retryRowsWithRelated = limitCardsForGuest(retryRes.rows as CardWithStatusRow[], user.isGuest)
       .map((row) => ({
         ...row,
         status: deriveLegacyStatus(row),
@@ -714,12 +721,12 @@ export async function getNextCard(mode: 'new' | 'review' = 'new', excludeIds?: s
       if (selected) return selected;
     }
 
-    const fallbackRes = await pool.query('SELECT * FROM knowledge_cards ORDER BY RANDOM() LIMIT 1;');
-    const fallbackCard = fallbackRes.rows[0] as KnowledgeCard | undefined;
+    const fallbackCards = user.isGuest ? limitCardsForGuest(MOCK_CARDS, true) : MOCK_CARDS;
+    const fallbackCard = fallbackCards[Math.floor(Math.random() * fallbackCards.length)];
     return fallbackCard ? withRelatedConcepts(fallbackCard) : null;
   } catch (error) {
     console.error('Error in getNextCard:', error);
-    const mockRows: CardWithStatusRow[] = MOCK_CARDS
+    const mockRows: CardWithStatusRow[] = limitCardsForGuest(MOCK_CARDS, user.isGuest)
       .filter((card) => !excluded.has(card.id))
       .map((card) => ({
         ...card,
@@ -797,7 +804,11 @@ function selectSmartSuggestedCard(cards: CardWithStatusRow[], mode: 'new' | 'rev
 }
 
 export async function saveCardState(cardId: string, status: CardStatus) {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
+
+  if (user.isGuest && !GUEST_CARD_IDS.has(cardId)) {
+    return { success: false, error: 'guest_card_not_available' };
+  }
 
   if (!process.env.DATABASE_URL) {
     return { success: true, warning: 'Mock mode: State not saved to DB' };
@@ -867,10 +878,10 @@ export async function saveCardState(cardId: string, status: CardStatus) {
 }
 
 export async function getSavedCards() {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
-    return MOCK_CARDS.map((c) => ({ ...c, status: 'saved', last_seen: new Date() }));
+    return limitCardsForGuest(MOCK_CARDS, user.isGuest).map((c) => ({ ...c, status: 'saved', last_seen: new Date() }));
   }
 
   try {
@@ -885,7 +896,7 @@ export async function getSavedCards() {
       ORDER BY ucs.last_seen DESC;
     `;
     const res = await pool.query(query, [user.id]);
-    return (res.rows as CardWithStatusRow[]).map((row) => ({
+    return limitCardsForGuest(res.rows as CardWithStatusRow[], user.isGuest).map((row) => ({
       ...row,
       status: deriveLegacyStatus(row) ?? 'saved',
     }));
@@ -896,7 +907,7 @@ export async function getSavedCards() {
 }
 
 export async function removeSavedCard(cardId: string) {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
     return { success: true, warning: 'Mock mode: not persisted' };
@@ -936,7 +947,7 @@ export async function removeSavedCard(cardId: string) {
 }
 
 export async function getUserStats() {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
     return { known: 12, saved: 5 };
@@ -975,14 +986,15 @@ export async function getAllCardsWithStatus(options?: {
   includeGenerated?: boolean;
   generatedLimit?: number;
 }) {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   const includeGenerated = options?.includeGenerated ?? false;
   const generatedLimit = Math.max(0, Math.min(options?.generatedLimit ?? DRILL_GENERATION_BATCH, 5000));
 
   if (!process.env.DATABASE_URL) {
+    const sourceCards = limitCardsForGuest(MOCK_CARDS, user.isGuest);
     const cards = includeGenerated
-      ? MOCK_CARDS
-      : MOCK_CARDS.filter((c) => !isExcludedFromKnowledgeMap(c.id));
+      ? sourceCards
+      : sourceCards.filter((c) => !isExcludedFromKnowledgeMap(c.id));
 
     const limited = includeGenerated
       ? [
@@ -1022,7 +1034,7 @@ export async function getAllCardsWithStatus(options?: {
       `;
 
       const res = await pool.query(query, [user.id]);
-      return (res.rows as CardWithStatusRow[])
+      return limitCardsForGuest(res.rows as CardWithStatusRow[], user.isGuest)
         .map((row) => ({ ...row, status: deriveLegacyStatus(row) }))
         .map((row) => withRelatedConcepts(row));
     }
@@ -1069,15 +1081,16 @@ export async function getAllCardsWithStatus(options?: {
       pool.query(generatedQuery, [user.id, generatedLimit]),
     ]);
 
-    const merged = [...coreRes.rows, ...generatedRes.rows] as CardWithStatusRow[];
+    const merged = limitCardsForGuest([...coreRes.rows, ...generatedRes.rows] as CardWithStatusRow[], user.isGuest);
     return merged
       .map((row) => ({ ...row, status: deriveLegacyStatus(row) }))
       .map((row) => withRelatedConcepts(row));
   } catch (error) {
     console.error('Error in getAllCardsWithStatus:', error);
+    const sourceCards = limitCardsForGuest(MOCK_CARDS, user.isGuest);
     const cards = includeGenerated
-      ? MOCK_CARDS
-      : MOCK_CARDS.filter((c) => !isExcludedFromKnowledgeMap(c.id));
+      ? sourceCards
+      : sourceCards.filter((c) => !isExcludedFromKnowledgeMap(c.id));
     const limited = includeGenerated
       ? [
           ...cards.filter((c) => !c.id.startsWith('drill_')),
@@ -1092,7 +1105,7 @@ export async function getAllCardsWithStatus(options?: {
 }
 
 export async function resetUserCardProgress() {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
     return { success: true, warning: 'Mock mode: not persisted' };
@@ -1168,7 +1181,7 @@ export async function getCardLeaderboard(): Promise<CardLeaderboardEntry[]> {
 }
 
 export async function getUserCardDomainProgress(): Promise<UserCardDomainProgress[]> {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
     return [];

--- a/apps/web/src/actions/graph-actions.ts
+++ b/apps/web/src/actions/graph-actions.ts
@@ -13,10 +13,10 @@ import {
 } from '@stem-brain/graph-engine';
 import type { ForceGraphData, GraphNodeWithKnowledge } from '@stem-brain/graph-engine';
 import { revalidatePath } from 'next/cache';
-import { requireCurrentUser } from '@/lib/auth';
+import { requireCurrentActor } from '@/lib/auth';
 
 async function getUserId() {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   return user.id;
 }
 

--- a/apps/web/src/actions/user-knowledge-actions.ts
+++ b/apps/web/src/actions/user-knowledge-actions.ts
@@ -3,7 +3,7 @@
 import { randomUUID } from 'node:crypto';
 import { revalidatePath } from 'next/cache';
 import pool from '@/lib/db';
-import { requireCurrentUser } from '@/lib/auth';
+import { requireCurrentActor } from '@/lib/auth';
 
 export type UserKnowledgeItem = {
   id: string;
@@ -67,7 +67,7 @@ function sanitizeContent(input: string) {
 }
 
 export async function getUserKnowledgeItems(): Promise<UserKnowledgeItem[]> {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
 
   if (!process.env.DATABASE_URL) {
     return memoryStore.get(user.id) ?? [];
@@ -89,7 +89,7 @@ export async function getUserKnowledgeItems(): Promise<UserKnowledgeItem[]> {
 }
 
 export async function createKnowledgeItem(formData: FormData): Promise<void> {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   const title = sanitizeTitle(String(formData.get('title') ?? ''));
   const content = sanitizeContent(String(formData.get('content') ?? ''));
   const topic = normalizeTopic(String(formData.get('topic') ?? ''));
@@ -156,7 +156,7 @@ export async function createKnowledgeItem(formData: FormData): Promise<void> {
 }
 
 export async function updateKnowledgeItem(formData: FormData): Promise<void> {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   const id = String(formData.get('id') ?? '').trim();
   const title = sanitizeTitle(String(formData.get('title') ?? ''));
   const content = sanitizeContent(String(formData.get('content') ?? ''));
@@ -194,7 +194,7 @@ export async function updateKnowledgeItem(formData: FormData): Promise<void> {
 }
 
 export async function deleteKnowledgeItem(formData: FormData): Promise<void> {
-  const user = await requireCurrentUser();
+  const user = await requireCurrentActor();
   const id = String(formData.get('id') ?? '').trim();
 
   if (!id) {

--- a/apps/web/src/app/api/graph/route.ts
+++ b/apps/web/src/app/api/graph/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getGraphDataForUser, getUserGraphStats } from '@stem-brain/graph-engine';
-import { getCurrentUser } from '@/lib/auth';
+import { getCurrentActor } from '@/lib/auth';
 
 export async function GET() {
-  const user = await getCurrentUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const user = await getCurrentActor();
 
   const graphData = getGraphDataForUser(user.id);
   const stats = getUserGraphStats(user.id);

--- a/apps/web/src/app/api/quiz_result/route.ts
+++ b/apps/web/src/app/api/quiz_result/route.ts
@@ -1,12 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { processQuizResult, getGraphDataForUser, runGlobalDiffusion } from '@stem-brain/graph-engine';
-import { getCurrentUser } from '@/lib/auth';
+import { getCurrentActor } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
-  const user = await getCurrentUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const user = await getCurrentActor();
 
   try {
     const body = await request.json();

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,7 +1,5 @@
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
 import { getUserCardDomainProgress, getUserStats } from '@/actions/card-actions';
 import { formatDomainLabel } from '@stem-brain/graph-engine';
 
@@ -65,9 +63,6 @@ function DomainCard({
 }
 
 export default async function DashboardPage() {
-  const user = await getCurrentUser();
-  if (!user) redirect('/login');
-
   const [stats, domains] = await Promise.all([getUserStats(), getUserCardDomainProgress()]);
 
   const totalReviewed = stats.known + stats.saved;

--- a/apps/web/src/app/knowledge/page.tsx
+++ b/apps/web/src/app/knowledge/page.tsx
@@ -1,16 +1,10 @@
 import { getAllCardsWithStatus } from '@/actions/card-actions';
 import KnowledgeMap from '@/components/knowledge-map';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
-import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
 export default async function KnowledgePage() {
-  const user = await getCurrentUser();
-  if (!user) {
-    redirect('/login');
-  }
   // Server component doesn't get searchParams by default; keep this page stable and let the
   // client component control query params by navigating to the same route.
   const cards = await getAllCardsWithStatus();

--- a/apps/web/src/app/my-knowledge/page.tsx
+++ b/apps/web/src/app/my-knowledge/page.tsx
@@ -1,7 +1,5 @@
-import { redirect } from 'next/navigation';
 import { randomUUID } from 'node:crypto';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
 import Link from 'next/link';
 import {
   createKnowledgeItem,
@@ -23,10 +21,6 @@ type MyKnowledgePageProps = {
 };
 
 export default async function MyKnowledgePage({ searchParams }: MyKnowledgePageProps) {
-  const user = await getCurrentUser();
-  if (!user) {
-    redirect('/login');
-  }
   const params = (await searchParams) ?? {};
   const query = (params.q ?? '').trim().toLowerCase();
   const topicFilter = (params.topic ?? 'all').trim().toLowerCase();
@@ -58,7 +52,7 @@ export default async function MyKnowledgePage({ searchParams }: MyKnowledgePageP
           <div>
             <h1 className="text-2xl font-bold text-gray-900">My Knowledge</h1>
             <p className="mt-1 text-sm text-gray-600">
-              Save your own notes, frameworks, and concepts. Everything here is private to your account.
+              Save your own notes, frameworks, and concepts. Everything here is private to your browser or account.
             </p>
           </div>
           <div className="rounded-lg border bg-white px-3 py-2 text-sm text-gray-600">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -79,16 +79,16 @@ export default async function HomePage() {
               ) : (
                 <>
                   <Link
-                    href="/signup"
+                    href="/practice"
                     className="rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-sky-100"
                   >
-                    Start practicing
+                    Start as guest
                   </Link>
                   <Link
-                    href="/login"
+                    href="/signup"
                     className="rounded-lg border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/15"
                   >
-                    Log in
+                    Create account
                   </Link>
                   <Link
                     href="#knowledge-graph"

--- a/apps/web/src/app/practice/page.tsx
+++ b/apps/web/src/app/practice/page.tsx
@@ -1,18 +1,14 @@
 import { getNextCard, getUserStats } from '@/actions/card-actions';
 import CardViewer from '@/components/card-viewer';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { getCurrentActor } from '@/lib/auth';
+import { GUEST_PRACTICE_CARD_LIMIT } from '@/lib/guest';
 
 export const dynamic = 'force-dynamic';
 
 export default async function PracticePage(props: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
-  const user = await getCurrentUser();
-  if (!user) {
-    redirect('/login');
-  }
-
+  const actor = await getCurrentActor();
   const searchParams = await props.searchParams;
   const mode = searchParams?.mode === 'review' ? 'review' : 'new';
 
@@ -53,7 +49,14 @@ export default async function PracticePage(props: { searchParams: Promise<{ [key
         </p>
 
         {/* Card viewer — stats are shown inside */}
-        <CardViewer key={mode} initialCard={initialCard} initialStats={stats} mode={mode} />
+        <CardViewer
+          key={mode}
+          initialCard={initialCard}
+          initialStats={stats}
+          mode={mode}
+          isGuest={actor.isGuest}
+          guestLimit={GUEST_PRACTICE_CARD_LIMIT}
+        />
       </div>
     </main>
   );

--- a/apps/web/src/app/ranking/page.tsx
+++ b/apps/web/src/app/ranking/page.tsx
@@ -1,7 +1,6 @@
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
+import { getCurrentActor } from '@/lib/auth';
 import { getCardLeaderboard } from '@/actions/card-actions';
 
 export const dynamic = 'force-dynamic';
@@ -13,8 +12,7 @@ function truncateUserId(userId: string): string {
 }
 
 export default async function RankingPage() {
-  const user = await getCurrentUser();
-  if (!user) redirect('/login');
+  const user = await getCurrentActor();
 
   const rows = await getCardLeaderboard();
 

--- a/apps/web/src/app/saved/page.tsx
+++ b/apps/web/src/app/saved/page.tsx
@@ -2,8 +2,6 @@ import { getSavedCards } from '@/actions/card-actions';
 import type { CardStatus, KnowledgeCard } from '@/actions/card-actions';
 import { removeSavedCard, resetUserCardProgress } from '@/actions/card-actions';
 import Navbar from '@/components/navbar';
-import { getCurrentUser } from '@/lib/auth';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { formatDomainLabel } from '@stem-brain/graph-engine';
 import ConfirmDeleteButton from '@/components/confirm-delete-button';
@@ -30,10 +28,6 @@ const STATUS_STYLES: Record<string, string> = {
 };
 
 export default async function SavedPage({ searchParams }: SavedPageProps) {
-  const user = await getCurrentUser();
-  if (!user) {
-    redirect('/login');
-  }
   const params = (await searchParams) ?? {};
   const query = (params.q ?? '').trim().toLowerCase();
   const domainFilter = (params.domain ?? 'all').trim().toLowerCase();

--- a/apps/web/src/components/card-viewer.tsx
+++ b/apps/web/src/components/card-viewer.tsx
@@ -9,6 +9,8 @@ interface CardViewerProps {
   initialCard: KnowledgeCard | null;
   initialStats: { known: number; saved: number };
   mode: 'new' | 'review';
+  isGuest?: boolean;
+  guestLimit?: number;
 }
 
 type HistoryEntry = {
@@ -16,7 +18,13 @@ type HistoryEntry = {
   action: 'skip' | CardStatus;
 };
 
-export default function CardViewer({ initialCard, initialStats, mode }: CardViewerProps) {
+export default function CardViewer({
+  initialCard,
+  initialStats,
+  mode,
+  isGuest = false,
+  guestLimit = 0,
+}: CardViewerProps) {
   const [card, setCard] = useState<KnowledgeCard | null>(initialCard);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -241,7 +249,9 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
           {mode === 'review' ? "You're all caught up on learning queue items!" : "All caught up on new/unknown cards!"}
         </p>
         <p className="text-gray-500 mt-2 text-sm leading-relaxed">
-          You reviewed {reviewedCount} card{reviewedCount !== 1 ? 's' : ''} this session.
+          {isGuest && mode === 'new'
+            ? `Guests can practice ${guestLimit} sample cards.`
+            : `You reviewed ${reviewedCount} card${reviewedCount !== 1 ? 's' : ''} this session.`}
         </p>
 
         <div className="mt-6 w-full grid grid-cols-2 gap-2 text-center">
@@ -256,6 +266,14 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
         </div>
 
         <div className="mt-6 flex flex-col gap-2 w-full">
+          {isGuest && (
+            <Link
+              href="/signup"
+              className="w-full rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-800 transition-colors text-center focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+            >
+              Create account for full practice
+            </Link>
+          )}
           <Link
             href="/practice?mode=review"
             className="w-full rounded-xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white hover:bg-blue-700 transition-colors text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -282,6 +300,15 @@ export default function CardViewer({ initialCard, initialStats, mode }: CardView
   // ── Active card ──────────────────────────────────────────────
   return (
     <div className="flex flex-col w-full max-w-md mx-auto">
+      {isGuest && mode === 'new' && (
+        <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Guest sample: {guestLimit} practice cards.{' '}
+          <Link href="/signup" className="font-semibold underline underline-offset-2">
+            Create an account
+          </Link>{' '}
+          for the full set.
+        </div>
+      )}
 
       {/* Stats / progress header — layout differs per mode */}
       <div className="mb-4 rounded-xl bg-white border border-gray-100 shadow-sm px-4 py-2.5">

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -56,7 +56,7 @@ export default async function Navbar() {
             )}
           </div>
 
-          {user ? <NavLinks /> : null}
+          <NavLinks />
         </div>
       </nav>
     </>

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,10 +1,16 @@
 import { auth, currentUser } from '@clerk/nextjs/server';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { hasValidClerkConfig } from '@/lib/clerk-env';
+import { GUEST_ID_COOKIE } from '@/lib/guest';
 
 export type AuthUser = {
   id: string;
   email: string;
+};
+
+export type CurrentActor = AuthUser & {
+  isGuest: boolean;
 };
 
 export async function getCurrentUser(): Promise<AuthUser | null> {
@@ -22,6 +28,24 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
     '';
 
   return { id: userId, email };
+}
+
+export async function getCurrentActor(): Promise<CurrentActor> {
+  const user = await getCurrentUser();
+  if (user) return { ...user, isGuest: false };
+
+  const cookieStore = await cookies();
+  const guestId = cookieStore.get(GUEST_ID_COOKIE)?.value;
+
+  return {
+    id: guestId?.startsWith('guest_') ? guestId : 'guest_anonymous',
+    email: 'Guest',
+    isGuest: true,
+  };
+}
+
+export async function requireCurrentActor(): Promise<CurrentActor> {
+  return getCurrentActor();
 }
 
 export async function requireCurrentUser(): Promise<AuthUser> {

--- a/apps/web/src/lib/guest.ts
+++ b/apps/web/src/lib/guest.ts
@@ -1,0 +1,2 @@
+export const GUEST_ID_COOKIE = 'girapphe_guest_id';
+export const GUEST_PRACTICE_CARD_LIMIT = 12;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,14 +1,39 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 import { NextResponse, type NextRequest, type NextFetchEvent } from 'next/server';
 import { hasValidClerkConfig } from '@/lib/clerk-env';
+import { GUEST_ID_COOKIE } from '@/lib/guest';
 
 const isPublicRoute = createRouteMatcher([
   '/',
+  '/dashboard(.*)',
+  '/knowledge(.*)',
   '/login(.*)',
+  '/my-knowledge(.*)',
+  '/practice(.*)',
+  '/ranking(.*)',
+  '/saved(.*)',
   '/signup(.*)',
   '/register(.*)',
+  '/api/graph(.*)',
   '/api/health(.*)',
+  '/api/quiz_result(.*)',
 ]);
+
+function ensureGuestCookie(request: NextRequest, response: NextResponse) {
+  const existing = request.cookies.get(GUEST_ID_COOKIE)?.value;
+  if (existing?.startsWith('guest_')) return response;
+
+  const guestId = `guest_${crypto.randomUUID()}`;
+  request.cookies.set(GUEST_ID_COOKIE, guestId);
+  response.cookies.set(GUEST_ID_COOKIE, guestId, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: request.nextUrl.protocol === 'https:',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365,
+  });
+  return response;
+}
 
 export default async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Redirect non-www to www in production
@@ -20,7 +45,7 @@ export default async function middleware(request: NextRequest, event: NextFetchE
   }
 
   if (!hasValidClerkConfig()) {
-    return NextResponse.next();
+    return ensureGuestCookie(request, NextResponse.next());
   }
 
   const handler = clerkMiddleware(async (auth, req) => {
@@ -31,7 +56,8 @@ export default async function middleware(request: NextRequest, event: NextFetchE
     }
   });
 
-  return handler(request, event);
+  const response = (await handler(request, event)) as NextResponse;
+  return ensureGuestCookie(request, response);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- allow signed-out visitors to use learning routes through a guest identity cookie
- limit guest practice to a 12-card sample set and show a signup prompt
- keep admin/auth-only routes protected while allowing guest graph/practice API access

## Validation
- pnpm --filter @stem-brain/web typecheck
- pnpm --filter @stem-brain/web lint