### PR TITLE
Polish home and deployment hygiene

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -2,9 +2,10 @@ name: CI and Deploy Cloudflare Worker
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
-      - dev
       - main
   workflow_dispatch:
 
@@ -39,67 +40,6 @@ jobs:
         run: pnpm build:cf
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ci_build_placeholder_1234567890
-
-  deploy_dev:
-    name: Deploy to Cloudflare (dev)
-    runs-on: ubuntu-latest
-    needs: ci
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        run: corepack enable && corepack prepare pnpm@9.15.4 --activate
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Validate Development Environment
-        working-directory: apps/web
-        run: pnpm check:env:dev:runtime
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
-          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /login
-          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /signup
-          NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: /practice
-          NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: /practice
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
-          APP_BASE_URL: ${{ vars.APP_BASE_URL_DEV }}
-
-      - name: Run Drizzle Migrations (dev)
-        working-directory: apps/web
-        run: pnpm db:migrate
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
-
-      - name: Deploy Worker (dev)
-        working-directory: apps/web
-        run: pnpm deploy:cf:dev
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
-          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /login
-          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /signup
-          NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: /practice
-          NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: /practice
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
-          APP_BASE_URL: ${{ vars.APP_BASE_URL_DEV }}
-          ADMIN_CLERK_USER_ID: ${{ secrets.ADMIN_CLERK_USER_ID_DEV }}
-
-      - name: Smoke Test (dev)
-        working-directory: apps/web
-        run: pnpm smoke
-        env:
-          SMOKE_BASE_URL: ${{ vars.APP_BASE_URL_DEV }}
 
   deploy_prod:
     name: Deploy to Cloudflare (prod)

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -85,10 +85,15 @@ jobs:
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /login
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /signup
+          NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: /practice
+          NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: /practice
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
           APP_BASE_URL: ${{ vars.APP_BASE_URL_DEV }}
+          ADMIN_CLERK_USER_ID: ${{ secrets.ADMIN_CLERK_USER_ID_DEV }}
 
       - name: Smoke Test (dev)
         working-directory: apps/web
@@ -141,10 +146,15 @@ jobs:
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /login
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /signup
+          NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: /practice
+          NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: /practice
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           APP_BASE_URL: ${{ vars.APP_BASE_URL }}
+          ADMIN_CLERK_USER_ID: ${{ secrets.ADMIN_CLERK_USER_ID }}
 
       - name: Smoke Test (prod)
         working-directory: apps/web

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ pnpm-lock.yaml.bak
 
 # testing
 coverage
+playwright-report/
+test-results/
 
 # turborepo
 .turbo/

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -68,6 +68,14 @@ npm run smoke
   - `200` with `"status":"ok"` in local fallback or DB healthy
   - `503` when DB configured but unavailable
 
+4. Browser smoke check
+```bash
+pnpm browser:smoke
+```
+
+This starts the web dev server automatically through Playwright. Use
+`PLAYWRIGHT_BASE_URL` only when testing an already-running local or remote app.
+
 ## 4. Production Required Config
 
 Required:
@@ -184,11 +192,13 @@ Key steps per deploy job:
   - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV`
   - `CLERK_SECRET_KEY_DEV`
   - `DATABASE_URL_DEV`
+  - `ADMIN_CLERK_USER_ID_DEV`
   - `CLOUDFLARE_API_TOKEN`
   - `CLOUDFLARE_ACCOUNT_ID`
   - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
   - `CLERK_SECRET_KEY`
   - `DATABASE_URL`
+  - `ADMIN_CLERK_USER_ID`
 - Variables:
   - `APP_BASE_URL_DEV`
   - `APP_BASE_URL`
@@ -316,18 +326,23 @@ Verified at: `2026-02-18 20:41:03 KST`
 
 ## 11. Branch and Environment Strategy
 
-This project uses **GitHub Flow** — no persistent `dev` branch.
+This project keeps environment branches explicit:
 
-- `main`: always deployable, auto-deploys to prod on push
-- Feature branches: created from `main`, merged back via PR
+- `dev`: protected integration branch; auto-deploys to Cloudflare `dev`.
+- `main`: protected production branch; auto-deploys to Cloudflare `prod`.
+- Feature branches: short-lived branches from the latest `dev` or `main`, merged by PR, then deleted.
 
 Basic flow:
 
-1. feature branch -> PR -> `main` -> prod auto-deploy
-2. Smoke test runs automatically after deploy
-3. Cloudflare Workers rollback available if smoke test fails
+1. Create a feature branch, for example `feature/practice-browser-smoke`.
+2. Open a PR into `dev`; CI runs quality checks.
+3. Merge to `dev`; GitHub Actions deploys the development Worker and runs smoke tests against `APP_BASE_URL_DEV`.
+4. Promote with a `dev` -> `main` PR.
+5. Merge to `main`; GitHub Actions deploys production and runs smoke tests against `APP_BASE_URL`.
+6. If production smoke fails, use Cloudflare Workers rollback and fix forward from a new branch.
 
-No staging branch. Use PR preview environments or local dev for pre-merge validation.
+Do not put real env files in git. Use `.env.local` only for local development,
+GitHub secrets/variables for CI, and Wrangler Worker secrets for Cloudflare runtime.
 
 ## 12. Progress Data Reset
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -204,7 +204,7 @@ Key steps per deploy job:
   - `APP_BASE_URL`
 
 Branch deploy behavior (current workflow):
-- `dev` branch push -> deploy to Cloudflare `dev` environment
+- PR to `main` -> runs Quality Checks
 - `main` branch push -> deploy to Cloudflare `prod` environment
 
 ## 7. Manual Steps You Must Do Yourself
@@ -326,20 +326,17 @@ Verified at: `2026-02-18 20:41:03 KST`
 
 ## 11. Branch and Environment Strategy
 
-This project keeps environment branches explicit:
+This project uses a short-lived feature-branch workflow:
 
-- `dev`: protected integration branch; auto-deploys to Cloudflare `dev`.
 - `main`: protected production branch; auto-deploys to Cloudflare `prod`.
-- Feature branches: short-lived branches from the latest `dev` or `main`, merged by PR, then deleted.
+- Feature branches: short-lived branches from the latest `main`, merged by PR, then deleted.
 
 Basic flow:
 
 1. Create a feature branch, for example `feature/practice-browser-smoke`.
-2. Open a PR into `dev`; CI runs quality checks.
-3. Merge to `dev`; GitHub Actions deploys the development Worker and runs smoke tests against `APP_BASE_URL_DEV`.
-4. Promote with a `dev` -> `main` PR.
-5. Merge to `main`; GitHub Actions deploys production and runs smoke tests against `APP_BASE_URL`.
-6. If production smoke fails, use Cloudflare Workers rollback and fix forward from a new branch.
+2. Open a PR into `main`; CI runs quality checks.
+3. Merge to `main`; GitHub Actions deploys production and runs smoke tests against `APP_BASE_URL`.
+4. If production smoke fails, use Cloudflare Workers rollback and fix forward from a new branch.
 
 Do not put real env files in git. Use `.env.local` only for local development,
 GitHub secrets/variables for CI, and Wrangler Worker secrets for Cloudflare runtime.

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -4,11 +4,11 @@ This project uses separate configuration for local development and production.
 
 ## 1. Environment Matrix
 
-| Environment | App Domain | Clerk Domain | Clerk Keys | Database |
-|---|---|---|---|---|
-| Local Dev | `http://localhost:3000` | active Clerk tenant | usually `pk_test` / `sk_test`, but `pk_live` / `sk_live` is also supported when intentionally sharing prod auth | optional Neon/local DB |
-| Cloudflare Dev | `*.workers.dev` or dev custom domain | active Clerk tenant | tenant-matched keys | dev or shared Neon DB |
-| Production | `https://www.girapphe.com` | `clerk.girapphe.com` | `pk_live` / `sk_live` | production Neon |
+| Environment | App Domain | Clerk Domain | Clerk Keys | Database | Deploy trigger |
+|---|---|---|---|---|---|
+| Local Dev | `http://localhost:3000` | active Clerk tenant | usually `pk_test` / `sk_test`, but `pk_live` / `sk_live` is also supported when intentionally sharing prod auth | optional Neon/local DB | manual |
+| Cloudflare Dev | `*.workers.dev` or dev custom domain | active Clerk tenant | tenant-matched keys | dev or shared Neon DB | push to `dev` |
+| Production | `https://www.girapphe.com` | `clerk.girapphe.com` | `pk_live` / `sk_live` | production Neon | push to `main` |
 
 ## 2. Where Secrets Live
 
@@ -57,14 +57,24 @@ Validation commands:
 - Local dev file check: `npm run check:env:dev`
 - Production env check (CI/runtime): `npm run check:env:prod`
 
-## 4. Deployment Rules
+## 4. Branch and Deployment Rules
 
 - Build/deploy production with production keys only.
 - Do not reuse dev keys for production domains.
-- This project uses **GitHub Flow**: `main` is the only long-lived branch.
+- This project uses two protected environment branches:
+  - `dev`: integration branch for development-network deployment.
+  - `main`: production branch and the only source for production deployment.
+- Feature branches are short-lived and should be named by scope, for example `feature/home-graph-polish`, `fix/admin-empty-state`, or `chore/env-runbook`.
 - GitHub Actions branch mapping:
-  - Push to `main` -> deploy `--env prod` -> smoke test
-- Feature branches are merged to `main` via PR and deleted after merge.
+  - PR to `dev` or `main` -> quality checks only
+  - Push to `dev` -> deploy `--env dev` -> smoke test dev URL
+  - Push to `main` -> deploy `--env prod` -> smoke test prod URL
+- Normal promotion path:
+  1. feature branch -> PR -> `dev`
+  2. smoke-test the Cloudflare dev deployment
+  3. `dev` -> PR -> `main`
+  4. smoke-test the production deployment
+- Delete feature branches after merge. Keep `dev` and `main` protected.
 
 ## 4.1 Codebase-Enforced Separation
 
@@ -86,6 +96,24 @@ Recommended secret commands:
 
 - Dev secret: `npx wrangler secret put KEY --env dev`
 - Prod secret: `npx wrangler secret put KEY --env prod`
+
+Secret classification:
+
+- Public/build-time values, safe to expose to browsers:
+  - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+  - `NEXT_PUBLIC_CLERK_SIGN_IN_URL`
+  - `NEXT_PUBLIC_CLERK_SIGN_UP_URL`
+  - `NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL`
+  - `NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL`
+  - `APP_BASE_URL`
+- Server-only secrets, never commit:
+  - `CLERK_SECRET_KEY`
+  - `DATABASE_URL`
+  - `ADMIN_CLERK_USER_ID`
+  - `CLOUDFLARE_API_TOKEN`
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - `R2_ACCESS_KEY_ID`
+  - `R2_SECRET_ACCESS_KEY`
 
 ## 5. Google OAuth 400 (invalid_request) Checklist
 

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -61,20 +61,17 @@ Validation commands:
 
 - Build/deploy production with production keys only.
 - Do not reuse dev keys for production domains.
-- This project uses two protected environment branches:
-  - `dev`: integration branch for development-network deployment.
-  - `main`: production branch and the only source for production deployment.
+- This project uses `main` as its protected deployment branch and the only
+  source for production deployment.
 - Feature branches are short-lived and should be named by scope, for example `feature/home-graph-polish`, `fix/admin-empty-state`, or `chore/env-runbook`.
 - GitHub Actions branch mapping:
-  - PR to `dev` or `main` -> quality checks only
-  - Push to `dev` -> deploy `--env dev` -> smoke test dev URL
+  - PR to `main` -> quality checks only
   - Push to `main` -> deploy `--env prod` -> smoke test prod URL
 - Normal promotion path:
-  1. feature branch -> PR -> `dev`
-  2. smoke-test the Cloudflare dev deployment
-  3. `dev` -> PR -> `main`
-  4. smoke-test the production deployment
-- Delete feature branches after merge. Keep `dev` and `main` protected.
+  1. feature branch -> PR -> `main`
+  2. merge after quality checks pass and all review conversations are resolved
+  3. smoke-test the production deployment
+- Delete feature branches after merge. Keep `main` protected.
 
 ## 4.1 Codebase-Enforced Separation
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ pnpm harness:deploy
 
 This runs the local harness first, then the Cloudflare/OpenNext build.
 
+Browser smoke checks use Playwright and start the web dev server automatically:
+
+```bash
+pnpm browser:smoke
+pnpm harness:browser
+```
+
+If Chromium is not installed locally yet, run:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+```
+
 Push is part of release handoff, not the repeatable validation script:
 
 ```bash
@@ -202,6 +215,18 @@ Clerk handles:
 - Multi-factor authentication (optional, configure in Clerk dashboard)
 
 ## Environments & Deployment
+
+Branch flow:
+
+```text
+feature/* -> PR -> dev -> deploy dev -> PR -> main -> deploy prod
+```
+
+- `dev` deploys to Cloudflare `dev` and uses dev-scoped secrets/variables.
+- `main` deploys to Cloudflare `prod` and uses production secrets/variables.
+- Do not commit real `.env*` files. Keep local values in `apps/web/.env.local`;
+  inject CI values with GitHub Secrets/Variables and Cloudflare runtime values
+  with Wrangler Worker secrets.
 
 Cloudflare Workers (OpenNext) commands:
 

--- a/README.md
+++ b/README.md
@@ -219,11 +219,13 @@ Clerk handles:
 Branch flow:
 
 ```text
-feature/* -> PR -> dev -> deploy dev -> PR -> main -> deploy prod
+feature/* -> PR -> Quality Checks -> main -> deploy prod
 ```
 
-- `dev` deploys to Cloudflare `dev` and uses dev-scoped secrets/variables.
 - `main` deploys to Cloudflare `prod` and uses production secrets/variables.
+- Pull requests run `Quality Checks`; Cloudflare preview deployments are not
+  configured until each PR can receive an isolated Worker, URL, and non-prod
+  runtime secrets.
 - Do not commit real `.env*` files. Keep local values in `apps/web/.env.local`;
   inject CI values with GitHub Secrets/Variables and Cloudflare runtime values
   with Wrangler Worker secrets.

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const toleratedConsoleErrors = [
+  /favicon\.ico/i,
+];
+
+const authEntrypointOrConfigFallback = /Sign in|Sign up|Clerk keys are missing|Live Clerk keys cannot be used/i;
+
+function attachBrowserFailureGuards(page: Page) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+
+    const text = message.text();
+    if (toleratedConsoleErrors.some((pattern) => pattern.test(text))) return;
+
+    consoleErrors.push(text);
+  });
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  return async () => {
+    // Give late hydration and browser console events a moment to surface.
+    await page.waitForTimeout(250);
+    expect(pageErrors, 'uncaught browser page errors').toEqual([]);
+    expect(consoleErrors, 'browser console errors').toEqual([]);
+  };
+}
+
+test.describe('browser smoke', () => {
+  test('health endpoint responds', async ({ request }) => {
+    const response = await request.get('/api/health');
+    expect(response.status()).toBe(200);
+  });
+
+  test('home page renders the app shell', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/');
+    await expect(page.locator('main#main-content')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Practice STEM concepts/i })).toBeVisible();
+
+    await assertNoBrowserFailures();
+  });
+
+  test('login page renders an auth entrypoint or local config fallback', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/login');
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('body')).toContainText(authEntrypointOrConfigFallback);
+
+    await assertNoBrowserFailures();
+  });
+
+  test('signup page renders an auth entrypoint or local config fallback', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/signup');
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('body')).toContainText(authEntrypointOrConfigFallback);
+
+    await assertNoBrowserFailures();
+  });
+
+  test('knowledge graph renders a non-empty graph surface', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/knowledge');
+    await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible({ timeout: 20_000 });
+
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeAttached({ timeout: 20_000 });
+
+    const box = await canvas.boundingBox();
+    expect(box?.width ?? 0, 'knowledge graph canvas width').toBeGreaterThan(0);
+    expect(box?.height ?? 0, 'knowledge graph canvas height').toBeGreaterThan(0);
+
+    await assertNoBrowserFailures();
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -35,6 +35,106 @@ html {
   view-transition-name: home-hero;
 }
 
+.home-hero-network {
+  mask-image: linear-gradient(to bottom, black 0%, black 78%, transparent 100%);
+}
+
+.home-hero-constellation {
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(226, 232, 240, 0.14) 0 0.42rem, transparent 0.48rem),
+    radial-gradient(circle at 32% 34%, rgba(125, 211, 252, 0.42) 0 0.34rem, transparent 0.4rem),
+    radial-gradient(circle at 68% 28%, rgba(52, 211, 153, 0.35) 0 0.3rem, transparent 0.36rem),
+    radial-gradient(circle at 76% 66%, rgba(251, 191, 36, 0.32) 0 0.3rem, transparent 0.36rem),
+    radial-gradient(circle at 28% 70%, rgba(56, 189, 248, 0.3) 0 0.28rem, transparent 0.34rem),
+    conic-gradient(from 92deg, transparent, rgba(125, 211, 252, 0.13), transparent 26%, rgba(52, 211, 153, 0.11), transparent 52%, rgba(251, 191, 36, 0.09), transparent 78%, rgba(125, 211, 252, 0.13), transparent);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 0 140px rgba(14, 165, 233, 0.14);
+  animation: homeConstellationTurn 26s linear infinite;
+}
+
+.home-hero-constellation::before,
+.home-hero-constellation::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  border-radius: 43% 57% 49% 51%;
+  transform: rotate(-18deg);
+}
+
+.home-hero-constellation::after {
+  inset: 25%;
+  border-color: rgba(251, 191, 36, 0.12);
+  transform: rotate(31deg);
+}
+
+.home-hero-node {
+  position: absolute;
+  display: grid;
+  min-width: 5.5rem;
+  min-height: 2.3rem;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.42);
+  color: rgb(226, 232, 240);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  box-shadow: 0 18px 48px rgba(2, 6, 23, 0.42);
+  backdrop-filter: blur(14px);
+  animation: homeHeroNodeFloat 7s ease-in-out infinite;
+}
+
+.home-hero-node-a {
+  right: max(7vw, calc((100vw - 72rem) / 2));
+  top: 18%;
+  border-color: rgba(125, 211, 252, 0.34);
+  color: rgb(186, 230, 253);
+}
+
+.home-hero-node-b {
+  right: max(16vw, calc((100vw - 58rem) / 2));
+  top: 52%;
+  border-color: rgba(251, 191, 36, 0.28);
+  color: rgb(254, 243, 199);
+  animation-delay: 1.1s;
+}
+
+.home-hero-node-c {
+  left: max(62vw, calc((100vw + 16rem) / 2));
+  top: 72%;
+  border-color: rgba(52, 211, 153, 0.32);
+  color: rgb(209, 250, 229);
+  animation-delay: 2s;
+}
+
+.home-hero-node-d {
+  left: auto;
+  right: max(8vw, calc((100vw - 74rem) / 2));
+  top: 42%;
+  border-color: rgba(45, 212, 191, 0.28);
+  color: rgb(204, 251, 241);
+  animation-delay: 2.8s;
+}
+
+@media (max-width: 640px) {
+  .home-hero-network {
+    opacity: 0.72;
+  }
+
+  .home-hero-constellation {
+    width: 34rem;
+    height: 34rem;
+  }
+
+  .home-hero-node {
+    display: none;
+  }
+}
+
 .home-hero-stage,
 .home-hero-copy,
 .home-hero-visual,
@@ -459,6 +559,27 @@ html {
   }
 }
 
+@keyframes homeConstellationTurn {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg) scale(1);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg) scale(1);
+  }
+}
+
+@keyframes homeHeroNodeFloat {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0.74;
+  }
+  50% {
+    transform: translate3d(0, -10px, 0);
+    opacity: 1;
+  }
+}
+
 @keyframes homeContourDrift {
   from {
     transform: translate3d(0, 0, 0) scale(1);
@@ -758,6 +879,8 @@ html {
   .home-hero-copy,
   .home-hero-visual,
   .home-discipline-track,
+  .home-hero-constellation,
+  .home-hero-node,
   .home-discipline-rail span {
     animation: none;
   }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -21,6 +21,11 @@ const HOME_FALLBACK_DOMAIN_PROGRESS: HomeDomainProgressRow[] = [
 
 const HOME_DOMAIN_TONES = ['bg-emerald-300', 'bg-sky-300', 'bg-amber-300', 'bg-cyan-300'] as const;
 const HOME_DISCIPLINES = ['Biology', 'Computer science', 'Semiconductor', 'Bio-chemistry', 'Medicine', 'Statistics', 'Economics', 'Architecture'];
+const HOME_HERO_SIGNALS = [
+  { label: 'Practice cards', value: '1k+' },
+  { label: 'Disciplines', value: '8' },
+  { label: 'Graph-first', value: '3D' },
+];
 
 const HOME_FALLBACK_STATS = {
   explainable: 18,
@@ -62,34 +67,35 @@ export default async function HomePage() {
       <div aria-hidden="true" className="home-scroll-progress fixed left-0 top-0 z-[70] h-0.5 w-full origin-left bg-gradient-to-r from-cyan-200 via-emerald-200 to-amber-200" />
       <Navbar user={user} />
 
-      <section className="home-snap-section home-hero-section relative z-10 mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col justify-start px-6 pb-14 pt-10 md:pb-20 md:pt-14">
-        <div className="home-hero-stage relative z-10 grid min-w-0 gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(20rem,0.55fr)] lg:items-start">
-          <div className="home-hero-copy fade-up min-w-0 max-w-3xl">
-            <p className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-xs font-semibold uppercase text-slate-300 shadow-sm backdrop-blur">
+      <section className="home-snap-section home-hero-section relative z-10 overflow-hidden px-6 pb-12 pt-10 md:pb-16 md:pt-14">
+        <div aria-hidden="true" className="home-hero-network pointer-events-none absolute inset-x-0 top-0 h-[calc(100vh-4rem)] min-h-[42rem]">
+          <div className="home-hero-constellation absolute left-1/2 top-[44%] h-[38rem] w-[38rem] -translate-x-1/2 -translate-y-1/2 md:h-[48rem] md:w-[48rem]" />
+          <div className="home-hero-node home-hero-node-a">Review</div>
+          <div className="home-hero-node home-hero-node-b">Notes</div>
+          <div className="home-hero-node home-hero-node-c">Mastery</div>
+          <div className="home-hero-node home-hero-node-d">Links</div>
+        </div>
+
+        <div className="home-hero-stage relative z-10 mx-auto flex min-h-[calc(100vh-10rem)] max-w-6xl flex-col justify-center">
+          <div className="home-hero-copy fade-up min-w-0 max-w-4xl">
+            <p className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.07] px-3 py-1 text-xs font-semibold uppercase text-slate-300 shadow-sm backdrop-blur">
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-cyan-200/80 shadow-[0_0_16px_rgba(125,211,252,0.65)]" />
               Multidisciplinary Practice Graph
             </p>
-            <h1 className="mt-5 max-w-[19rem] text-2xl font-black leading-tight tracking-tight text-white sm:max-w-2xl sm:text-4xl md:text-6xl">
-              Practice STEM concepts and build your knowledge graph.
+            <h1 className="mt-5 max-w-3xl text-5xl font-black leading-[0.98] tracking-tight text-white sm:text-6xl md:text-7xl">
+              Practice STEM concepts and build your{' '}
+              <span className="text-cyan-300">knowledge graph.</span>
             </h1>
-            <p className="mt-5 max-w-[20rem] text-sm leading-7 text-slate-300 sm:max-w-2xl sm:text-base md:text-lg">
+            <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 md:text-lg">
               Learn with focused concept cards, save weak spots for review, and see your progress across science, engineering, medicine, computing, economics, and design.
             </p>
 
-            <div className="home-discipline-rail mt-7 max-w-2xl overflow-hidden text-xs font-semibold uppercase text-slate-300" data-carousel="disciplines">
-              <div className="home-discipline-track flex w-max" aria-label="STEM disciplines" style={{ animationName: 'homeDisciplineCarousel' }}>
-                {[0, 1].map((groupIndex) => (
-                  <div
-                    key={groupIndex}
-                    aria-hidden={groupIndex === 1 ? 'true' : undefined}
-                    className="home-discipline-group flex shrink-0 gap-2 pr-2"
-                  >
-                    {HOME_DISCIPLINES.map((label) => (
-                      <span key={`${label}-${groupIndex}`} className="shrink-0 rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 backdrop-blur">
-                        {label}
-                      </span>
-                    ))}
-                  </div>
+            <div className="mt-7 max-w-3xl text-xs font-semibold uppercase text-slate-300">
+              <div className="flex flex-wrap gap-2" aria-label="STEM disciplines">
+                {HOME_DISCIPLINES.map((label) => (
+                  <span key={label} className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 backdrop-blur">
+                    {label}
+                  </span>
                 ))}
               </div>
             </div>
@@ -152,7 +158,16 @@ export default async function HomePage() {
               </div>
             ) : null}
           </div>
-
+        </div>
+        <div className="relative z-10 mx-auto mt-8 grid max-w-6xl gap-5 lg:-mt-8 lg:grid-cols-[minmax(0,0.56fr)_minmax(22rem,0.44fr)] lg:items-end">
+          <div className="grid gap-3 sm:grid-cols-3">
+            {HOME_HERO_SIGNALS.map((signal) => (
+              <div key={signal.label} className="rounded-lg border border-white/10 bg-white/[0.055] px-4 py-3 backdrop-blur">
+                <span className="block text-2xl font-black text-white">{signal.value}</span>
+                <span className="text-xs font-semibold uppercase text-slate-400">{signal.label}</span>
+              </div>
+            ))}
+          </div>
           <div className="home-hero-visual fade-up min-w-0">
             <KnowledgeSurface
               domainProgress={homeDomainProgress}
@@ -164,7 +179,7 @@ export default async function HomePage() {
             />
           </div>
         </div>
-        <div className="mt-10 flex flex-col items-center gap-4">
+        <div className="relative z-10 mx-auto mt-8 flex max-w-6xl flex-col items-center gap-4">
           <Link
             href="#knowledge-graph"
             aria-label="Scroll to live knowledge graph"

--- a/apps/web/src/components/brand-logo.tsx
+++ b/apps/web/src/components/brand-logo.tsx
@@ -8,9 +8,9 @@ type BrandLogoProps = {
 
 export default function BrandLogo({ className = '', textClassName = '', iconClassName = '' }: BrandLogoProps) {
   return (
-    <span className={`inline-flex items-center gap-2 ${className}`.trim()}>
-      <LogoMark className={iconClassName} />
-      <span className={`font-bold tracking-tight text-slate-900 ${textClassName}`.trim()}>
+    <span className={`inline-flex min-w-0 items-center gap-2 ${className}`.trim()}>
+      <LogoMark className={`shrink-0 ${iconClassName}`.trim()} />
+      <span className={`truncate font-bold tracking-tight text-slate-900 ${textClassName}`.trim()}>
         STEM<span className="text-sky-600">Brain</span>
       </span>
     </span>

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -21,8 +21,8 @@ export default function NavLinks() {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Main navigation">
-      <ul className="no-scrollbar flex items-center gap-1 overflow-x-auto rounded-lg bg-slate-100 p-1 text-sm font-medium text-slate-600">
+    <nav aria-label="Main navigation" className="min-w-0 overflow-hidden">
+      <ul className="no-scrollbar flex w-full min-w-0 items-center gap-1 overflow-x-auto rounded-lg bg-slate-100 p-1 text-sm font-medium text-slate-600">
         {NAV_ITEMS.map((item) => {
           const active = isActive(pathname, item.href);
           return (

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -18,16 +18,16 @@ export default async function Navbar({ user: initialUser }: { user?: AuthUser | 
 
       <nav
         aria-label="Site header"
-        className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 px-4 py-3 text-slate-800 backdrop-blur"
+        className="sticky top-0 z-40 overflow-hidden border-b border-slate-200 bg-white/95 px-4 py-3 text-slate-800 backdrop-blur"
       >
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3">
-          <div className="flex items-center justify-between gap-4">
-            <Link href="/" aria-label="STEMBrain — go to home" className="inline-flex items-center">
+        <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-3">
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <Link href="/" aria-label="STEMBrain — go to home" className="inline-flex min-w-0 items-center">
               <BrandLogo textClassName="text-xl" />
             </Link>
 
             {user ? (
-              <div className="flex items-center gap-3 text-sm font-medium">
+              <div className="flex shrink-0 items-center gap-3 text-sm font-medium">
                 <span
                   className="hidden rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 md:inline"
                   title={user.email}
@@ -45,7 +45,7 @@ export default async function Navbar({ user: initialUser }: { user?: AuthUser | 
                 </form>
               </div>
             ) : (
-              <div className="flex items-center gap-2 text-sm font-medium">
+              <div className="flex shrink-0 items-center gap-2 text-sm font-medium">
                 <Link href="/login" className="rounded-md border px-3 py-1.5 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500">
                   Log in
                 </Link>

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -78,10 +78,8 @@ git push
 Branch and environment handoff:
 
 1. Work on a short-lived branch such as `feature/...`, `fix/...`, or `chore/...`.
-2. Open a PR into `dev`; CI runs quality checks.
-3. Merge to `dev` for the development-network Cloudflare deploy and smoke test.
-4. Promote with a `dev` -> `main` PR.
-5. Merge to `main` for the production Cloudflare deploy and smoke test.
+2. Open a PR into `main`; CI runs quality checks.
+3. Merge to `main` for the production Cloudflare deploy and smoke test.
 
 After pushing, wait for CI to finish. Deploy through the configured Cloudflare
 pipeline or run the deployment command for the target environment.

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -55,6 +55,19 @@ pnpm harness:deploy
 
 The deployment harness runs the local harness first, then `pnpm build:cf`.
 
+Browser smoke checks use Playwright and start the web dev server automatically:
+
+```bash
+pnpm browser:smoke
+pnpm harness:browser
+```
+
+If Chromium is not installed locally yet, run:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+```
+
 Release handoff checklist:
 
 ```bash
@@ -62,7 +75,15 @@ git status --short
 git push
 ```
 
-After pushing, wait for CI to finish, then deploy through the configured Cloudflare
+Branch and environment handoff:
+
+1. Work on a short-lived branch such as `feature/...`, `fix/...`, or `chore/...`.
+2. Open a PR into `dev`; CI runs quality checks.
+3. Merge to `dev` for the development-network Cloudflare deploy and smoke test.
+4. Promote with a `dev` -> `main` PR.
+5. Merge to `main` for the production Cloudflare deploy and smoke test.
+
+After pushing, wait for CI to finish. Deploy through the configured Cloudflare
 pipeline or run the deployment command for the target environment.
 
 Optional smoke test (app must be running):
@@ -113,7 +134,8 @@ Cloudflare/OpenNext commands:
 
 ```bash
 npm run build:cf
-npm run deploy:cf
+npm run deploy:cf:dev
+npm run deploy:cf:prod
 ```
 
 See `DEPLOY.md` for full runbook and CI template.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,16 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "check": "turbo check",
+    "env:setup:dev": "pnpm --filter @stem-brain/web env:setup:dev",
+    "check:env:dev": "pnpm --filter @stem-brain/web check:env:dev",
+    "check:env:prod": "pnpm --filter @stem-brain/web check:env:prod",
+    "check:env:examples": "pnpm --filter @stem-brain/web check:env:examples",
     "smoke": "pnpm --filter @stem-brain/web smoke",
+    "browser:smoke": "playwright test",
+    "browser:smoke:headed": "playwright test --headed",
     "harness": "pnpm harness:local",
     "harness:local": "pnpm check && pnpm --filter @stem-brain/web check:env:examples && pnpm --filter @stem-brain/web build",
+    "harness:browser": "pnpm harness:local && pnpm browser:smoke",
     "harness:ci": "pnpm install --frozen-lockfile && pnpm harness:local",
     "harness:deploy": "pnpm harness:local && pnpm build:cf",
     "deploy:cf": "pnpm --filter @stem-brain/web deploy:cf",
@@ -20,6 +27,7 @@
     "deploy:cf:prod": "pnpm --filter @stem-brain/web deploy:cf:prod"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "turbo": "^2.5.4"
   },
   "engines": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
+
+export default defineConfig({
+  testDir: './apps/web/e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm --filter @stem-brain/web dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+    {
+      name: 'chromium-mobile',
+      use: {
+        ...devices['Pixel 7'],
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       turbo:
         specifier: ^2.5.4
         version: 2.8.19
@@ -62,7 +65,7 @@ importers:
         version: 3.1012.0
       '@clerk/nextjs':
         specifier: ^6.37.5
-        version: 6.39.0(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 6.39.0(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -80,7 +83,7 @@ importers:
         version: 0.16.38
       next:
         specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       pg:
         specifier: ^8.18.0
         version: 8.20.0
@@ -99,7 +102,7 @@ importers:
     devDependencies:
       '@opennextjs/cloudflare':
         specifier: ^1.16.5
-        version: 1.17.1(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.75.0)
+        version: 1.17.1(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.75.0)
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -2382,6 +2385,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -4656,6 +4664,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6067,6 +6080,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -8731,13 +8754,13 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.39.0(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@clerk/nextjs@6.39.0(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@clerk/backend': 2.33.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/clerk-react': 5.61.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/shared': 3.47.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/types': 4.101.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       server-only: 0.0.1
@@ -10162,7 +10185,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/aws@3.9.16(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@opennextjs/aws@3.9.16(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -10178,7 +10201,7 @@ snapshots:
       cookie: 1.1.1
       esbuild: 0.25.4
       express: 5.2.1
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
       yaml: 2.8.2
@@ -10186,16 +10209,16 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.17.1(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.75.0)':
+  '@opennextjs/cloudflare@1.17.1(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.75.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.16(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@opennextjs/aws': 3.9.16(next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       cloudflare: 4.5.0
       comment-json: 4.6.2
       enquirer: 2.4.1
       glob: 12.0.0
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-tqdm: 0.8.6
       wrangler: 4.75.0
       yargs: 18.0.0
@@ -10206,6 +10229,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -13049,6 +13076,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14197,7 +14227,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -14216,6 +14246,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -14519,6 +14550,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-TEMPLATE="$ROOT_DIR/.env.dev.example"
-TARGET="$ROOT_DIR/.env.local"
+APP_DIR="$ROOT_DIR/apps/web"
+TEMPLATE="$APP_DIR/.env.dev.example"
+TARGET="$APP_DIR/.env.local"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "[ERROR] Missing template: $TEMPLATE"
@@ -19,6 +20,6 @@ fi
 
 echo ""
 echo "Next steps:"
-echo "1) Fill real dev values in .env.local (pk_test/sk_test recommended)"
+echo "1) Fill real dev values in apps/web/.env.local (pk_test/sk_test recommended)"
 echo "2) Run: npm run check:env:dev"
 echo "3) Run: npm run dev"


### PR DESCRIPTION
## What changed

- Polished the homepage first viewport into a full-bleed graph-led hero with stronger typography, accent color, static discipline chips, and a visible knowledge-system preview below the fold.
- Fixed mobile/header layout constraints so the brand, auth controls, and horizontal nav do not create page-level overflow.
- Added Playwright browser smoke coverage for health, home, auth entrypoints, and the knowledge graph canvas across desktop and mobile Chromium.
- Aligned dev/prod branch and deploy docs with the protected `dev` -> `main` promotion flow.
- Fixed local env setup so root commands create `apps/web/.env.local` from the correct template, and ensured CI deploy steps receive the needed redirect/admin env values.

## Review notes

- Checked the diff for accidental real secrets. Only placeholder env examples are present.
- Verified mobile horizontal overflow is gone on the homepage (`scrollWidth === innerWidth`).
- The visible Next.js dev indicator can overlap the lower-left CTA area in local dev screenshots; this is not present in production builds.

## Validation

- `pnpm harness`
- `pnpm browser:smoke` (10 passed)
- Manual Playwright screenshot QA at desktop `1440x900` and Pixel 7 mobile viewport
- Manual Playwright interaction: `Start as guest` navigates to `/practice`
