### PR TITLE
Improve practice mode accessibility

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -47,6 +47,18 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
+  test('practice mode navigation identifies the active mode', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/practice?mode=review');
+
+    const practiceMode = page.getByRole('navigation', { name: 'Practice mode' });
+    await expect(practiceMode.getByRole('link', { name: 'Review' })).toHaveAttribute('aria-current', 'page');
+    await expect(practiceMode.getByRole('link', { name: 'Learn New' })).not.toHaveAttribute('aria-current');
+
+    await assertNoBrowserFailures();
+  });
+
   test('login page renders an auth entrypoint or local config fallback', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/src/app/practice/page.tsx
+++ b/apps/web/src/app/practice/page.tsx
@@ -28,20 +28,25 @@ export default async function PracticePage(props: { searchParams: Promise<{ [key
         </div>
 
         {/* Mode Toggle */}
-        <div className="mb-2 flex w-full max-w-lg bg-gray-200 p-1 rounded-lg">
+        <nav
+          aria-label="Practice mode"
+          className="mb-2 flex w-full max-w-lg bg-gray-200 p-1 rounded-lg"
+        >
           <Link 
             href="/practice?mode=new" 
+            aria-current={mode === 'new' ? 'page' : undefined}
             className={`px-4 py-2 rounded-md text-sm font-medium transition-colors flex-1 text-center ${mode === 'new' ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
           >
             Learn New
           </Link>
           <Link
             href="/practice?mode=review"
+            aria-current={mode === 'review' ? 'page' : undefined}
             className={`px-4 py-2 rounded-md text-sm font-medium transition-colors flex-1 text-center ${mode === 'review' ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
           >
             Review
           </Link>
-        </div>
+        </nav>
         <p className="mb-6 text-xs text-gray-500">
           {mode === 'new'
             ? 'Learn New: unseen and unclear cards first'


### PR DESCRIPTION
## What changed
- Expose the practice-mode switch as labelled navigation.
- Mark the selected learning mode with `aria-current`.
- Add desktop and mobile browser coverage for the active-mode state.

## Validation
- `pnpm --filter @stem-brain/web check`
- `pnpm browser:smoke --grep "practice mode navigation identifies the active mode"`