### PR TITLE
Respect reduced motion preferences on home

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -59,6 +59,16 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
+  test('home respects reduced-motion preferences', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/');
+
+    await expect(page.locator('.home-scroll-cue')).toHaveCSS('animation-iteration-count', '1');
+    await assertNoBrowserFailures();
+  });
+
   test('login page renders an auth entrypoint or local config fallback', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -21,6 +21,21 @@ html {
   scroll-padding-top: 5rem;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .home-shell *,
+  .home-shell *::before,
+  .home-shell *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 .home-shell {
   scroll-snap-type: y proximity;
   view-transition-name: home-shell;

--- a/apps/web/src/components/home-domain-progress.tsx
+++ b/apps/web/src/components/home-domain-progress.tsx
@@ -41,16 +41,26 @@ export default function HomeDomainProgress({
 }) {
   const frames = useMemo(() => buildFrames(rows, demo), [rows, demo]);
   const [frameIndex, setFrameIndex] = useState(0);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useEffect(() => {
-    if (frames.length <= 1) return undefined;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener('change', updatePreference);
+    return () => mediaQuery.removeEventListener('change', updatePreference);
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion || frames.length <= 1) return undefined;
 
     const interval = window.setInterval(() => {
       setFrameIndex((current) => (current + 1) % frames.length);
     }, ROTATION_INTERVAL_MS);
 
     return () => window.clearInterval(interval);
-  }, [frames.length]);
+  }, [frames.length, prefersReducedMotion]);
 
   const activeRows = frames[frames.length > 0 ? frameIndex % frames.length : 0] ?? [];
 

--- a/apps/web/src/components/home-graph-scene.tsx
+++ b/apps/web/src/components/home-graph-scene.tsx
@@ -210,9 +210,19 @@ export default function HomeGraphScene({ demo = false, explainable, unclear, not
   const [demoGraphClicked, setDemoGraphClicked] = useState(false);
   const [activeCaseKey, setActiveCaseKey] = useState<LearningCaseKey>('explore');
   const [isAutoCycling, setIsAutoCycling] = useState(true);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const activeCase = LEARNING_CASES[activeCaseKey];
   const activeStatusGroup = activeCase.activeGroup;
   const activeGraphGroup: ActiveGroup = demo ? activeDemoGroup : activeStatusGroup;
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener('change', updatePreference);
+    return () => mediaQuery.removeEventListener('change', updatePreference);
+  }, []);
 
   useEffect(() => {
     const element = graphContainerRef.current;
@@ -233,7 +243,7 @@ export default function HomeGraphScene({ demo = false, explainable, unclear, not
   }, []);
 
   useEffect(() => {
-    if (!demo) return;
+    if (!demo || prefersReducedMotion) return;
 
     const intervalId = window.setInterval(() => {
       setActiveDemoGroup((current) => {
@@ -243,10 +253,10 @@ export default function HomeGraphScene({ demo = false, explainable, unclear, not
     }, 3400);
 
     return () => window.clearInterval(intervalId);
-  }, [demo]);
+  }, [demo, prefersReducedMotion]);
 
   useEffect(() => {
-    if (demo || !isAutoCycling) return;
+    if (demo || !isAutoCycling || prefersReducedMotion) return;
 
     const intervalId = window.setInterval(() => {
       setActiveCaseKey((current) => {
@@ -256,18 +266,18 @@ export default function HomeGraphScene({ demo = false, explainable, unclear, not
     }, 3400);
 
     return () => window.clearInterval(intervalId);
-  }, [demo, isAutoCycling]);
+  }, [demo, isAutoCycling, prefersReducedMotion]);
 
   const enableOrbit = useCallback(() => {
     const controls = graphRef.current?.controls?.();
     if (!controls) return;
 
-    controls.autoRotate = true;
+    controls.autoRotate = !prefersReducedMotion;
     controls.autoRotateSpeed = demo ? 0.62 : activeCase.orbitSpeed;
     controls.enablePan = false;
     controls.minDistance = 90;
     controls.maxDistance = 430;
-  }, [activeCase.orbitSpeed, demo]);
+  }, [activeCase.orbitSpeed, demo, prefersReducedMotion]);
 
   useEffect(() => {
     enableOrbit();


### PR DESCRIPTION
## What changed
- Stop rotating home progress and graph scenes when the visitor prefers reduced motion.
- Disable decorative home animations and smooth scrolling under that preference.
- Add browser coverage for the reduced-motion presentation.

## Validation
- `pnpm --filter @stem-brain/web check`
- `pnpm browser:smoke --grep "home respects reduced-motion preferences"`