### PR TITLE
Improve not-found recovery

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -69,6 +69,13 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
+  test('unknown routes provide a usable not-found recovery', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+
+    await expect(page.locator('main#main-content')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Return Home' })).toHaveAttribute('href', '/');
+  });
   test('login page renders an auth entrypoint or local config fallback', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -2,12 +2,13 @@ import Link from 'next/link';
  
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <h2 className="text-2xl font-bold mb-4">Not Found</h2>
-      <p className="mb-4">Could not find requested resource</p>
+    <main id="main-content" className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">404 error</p>
+      <h1 className="mt-2 text-2xl font-bold text-slate-900">Page not found</h1>
+      <p className="mt-4 max-w-md text-slate-600">The page you requested does not exist or may have moved.</p>
       <Link href="/" className="text-blue-500 hover:underline">
         Return Home
       </Link>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## What changed
- Make the 404 route a semantic main-content recovery screen.
- Use a clear page-not-found heading and guidance.
- Add desktop and mobile browser coverage for the recovery link.

## Validation
- `pnpm --filter @stem-brain/web check`
- `pnpm browser:smoke --grep "unknown routes provide a usable not-found recovery"`