### PR TITLE
Improve global error recovery

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import Link from 'next/link';
 
 export default function GlobalError({
   error,
@@ -30,12 +31,20 @@ export default function GlobalError({
     <main id="main-content" className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
       <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-bold focus:outline-none">Something went wrong</h1>
       <p className="max-w-md text-sm text-slate-600">Try the request again. If the problem continues, return home and retry later.</p>
-      <button
-        onClick={reset}
-        className="rounded-md border px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
-      >
-        Try again
-      </button>
+      <div className="flex flex-wrap justify-center gap-3">
+        <button
+          onClick={reset}
+          className="rounded-md border px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+        >
+          Return home
+        </Link>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function GlobalError({
   error,
@@ -9,6 +9,8 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
   useEffect(() => {
     // ChunkLoadError occurs when a new deployment invalidates cached JS chunks.
     // Automatically reload the page to fetch the latest assets.
@@ -17,6 +19,7 @@ export default function GlobalError({
       return;
     }
     console.error(error);
+    headingRef.current?.focus();
   }, [error]);
 
   if (error.name === 'ChunkLoadError' || error.message?.includes('Failed to load chunk')) {
@@ -24,14 +27,15 @@ export default function GlobalError({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
-      <h2 className="text-2xl font-bold">Something went wrong</h2>
+    <main id="main-content" className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-bold focus:outline-none">Something went wrong</h1>
+      <p className="max-w-md text-sm text-slate-600">Try the request again. If the problem continues, return home and retry later.</p>
       <button
         onClick={reset}
         className="rounded-md border px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
       >
         Try again
       </button>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## What changed
- Make global errors a semantic main-content recovery screen.
- Move focus to the error heading so keyboard and screen-reader users are informed immediately.
- Add practical recovery guidance.

## Validation
- `pnpm --filter @stem-brain/web check`