### PR TITLE
Expose practice answer reveal state

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -59,6 +59,19 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
+  test('practice answer control exposes its reveal state', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.goto('/practice');
+
+    const revealButton = page.getByRole('button', { name: 'Show answer' });
+    await expect(revealButton).toHaveAttribute('aria-expanded', 'false');
+    await revealButton.click();
+    await expect(page.getByRole('button', { name: 'Hide answer' })).toHaveAttribute('aria-expanded', 'true');
+
+    await assertNoBrowserFailures();
+  });
+
   test('home respects reduced-motion preferences', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -67,7 +67,11 @@ test.describe('browser smoke', () => {
     const revealButton = page.getByRole('button', { name: 'Show answer' });
     await expect(revealButton).toHaveAttribute('aria-expanded', 'false');
     await revealButton.click();
-    await expect(page.getByRole('button', { name: 'Hide answer' })).toHaveAttribute('aria-expanded', 'true');
+
+    const hideButton = page.getByRole('button', { name: 'Hide answer' });
+    await expect(hideButton).toHaveAttribute('aria-expanded', 'true');
+    await hideButton.click();
+    await expect(page.getByRole('button', { name: 'Show answer' })).toHaveAttribute('aria-expanded', 'false');
 
     await assertNoBrowserFailures();
   });

--- a/apps/web/src/components/card-viewer.tsx
+++ b/apps/web/src/components/card-viewer.tsx
@@ -433,10 +433,14 @@ export default function CardViewer({
         onClick={() => setRevealed((prev) => !prev)}
         disabled={loading}
         aria-label={revealed ? 'Hide answer' : 'Show answer'}
+        aria-expanded={revealed}
         className="mt-3 w-full py-4 bg-gray-900 hover:bg-gray-700 active:scale-95 text-white font-semibold rounded-2xl transition-all text-sm tracking-wide disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-700"
       >
         {revealed ? 'Hide Answer ↑' : 'Show Answer ↓'}
       </button>
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {revealed ? 'Answer is shown. You can now rate this card.' : 'Answer is hidden. Recall the concept before revealing it.'}
+      </p>
 
       {/* ── AFTER reveal: Unclear | Can Explain + Undo ── */}
       {revealed && (

--- a/apps/web/src/components/card-viewer.tsx
+++ b/apps/web/src/components/card-viewer.tsx
@@ -438,9 +438,6 @@ export default function CardViewer({
       >
         {revealed ? 'Hide Answer ↑' : 'Show Answer ↓'}
       </button>
-      <p className="sr-only" aria-live="polite" aria-atomic="true">
-        {revealed ? 'Answer is shown. You can now rate this card.' : 'Answer is hidden. Recall the concept before revealing it.'}
-      </p>
 
       {/* ── AFTER reveal: Unclear | Can Explain + Undo ── */}
       {revealed && (


### PR DESCRIPTION
## What changed
- Expose the answer reveal state through `aria-expanded`.
- Rely on the disclosure control state instead of a duplicate live-region announcement.
- Cover reveal and collapse behavior in the desktop and mobile Playwright projects.

## Validation
- GitHub Actions: Quality Checks
  - Validate Env Templates
  - Lint and Typecheck
  - Build Cloudflare Bundle
- `pnpm browser:smoke --grep "practice answer control exposes its reveal state"`