### PR TITLE
Show review queue size in practice

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -53,7 +53,7 @@ test.describe('browser smoke', () => {
     await page.goto('/practice?mode=review');
 
     const practiceMode = page.getByRole('navigation', { name: 'Practice mode' });
-    await expect(practiceMode.getByRole('link', { name: 'Review' })).toHaveAttribute('aria-current', 'page');
+    await expect(practiceMode.getByRole('link', { name: /Review .*card.*needing review/i })).toHaveAttribute('aria-current', 'page');
     await expect(practiceMode.getByRole('link', { name: 'Learn New' })).not.toHaveAttribute('aria-current');
 
     await assertNoBrowserFailures();

--- a/apps/web/src/app/practice/page.tsx
+++ b/apps/web/src/app/practice/page.tsx
@@ -43,9 +43,10 @@ export default async function PracticePage(props: { searchParams: Promise<{ [key
           <Link
             href="/practice?mode=review"
             aria-current={mode === 'review' ? 'page' : undefined}
+            aria-label={`Review ${stats.unclear} card${stats.unclear === 1 ? '' : 's'} needing review`}
             className={`flex-1 rounded-md px-4 py-2 text-center text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-200 ${mode === 'review' ? 'bg-white text-gray-900 shadow' : 'text-gray-500 hover:text-gray-700'}`}
           >
-            Review
+            Review ({stats.unclear})
           </Link>
         </nav>
         <p id="practice-mode-description" className="mb-6 text-xs text-gray-500">


### PR DESCRIPTION
## What changed
- Show the number of cards awaiting review in the practice-mode control.
- Keep an explicit accessible label and update the smoke assertion.

## Validation
- pnpm --filter @stem-brain/web typecheck
- git diff --check