### PR TITLE
Harden quiz API and health responses

### DIFF
--- a/apps/web/drizzle/migrations/0005_add_quiz_rate_limits.sql
+++ b/apps/web/drizzle/migrations/0005_add_quiz_rate_limits.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "user_quiz_rate_limits" (
+  "user_id" text PRIMARY KEY,
+  "next_allowed_at" timestamp with time zone NOT NULL
+);

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773134159601,
       "tag": "0002_seed_knowledge_cards",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786525500000,
+      "tag": "0005_add_quiz_rate_limits",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -92,6 +92,11 @@ export const userKnowledgeStates = pgTable("user_knowledge_states", {
   index("idx_user_knowledge_states_source_type").on(t.sourceType),
 ]);
 
+export const userQuizRateLimits = pgTable("user_quiz_rate_limits", {
+  userId: text("user_id").primaryKey(),
+  nextAllowedAt: timestamp("next_allowed_at", { withTimezone: true }).notNull(),
+});
+
 export const userKnowledgeEvidence = pgTable("user_knowledge_evidence", {
   id: serial("id").primaryKey(),
   userId: text("user_id").notNull(),

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -38,6 +38,15 @@ test.describe('browser smoke', () => {
     expect(response.status()).toBe(200);
   });
 
+  test('quiz mutation rejects unauthenticated callers', async ({ request }) => {
+    const response = await request.post('/api/quiz_result', {
+      data: { node_id: 'math_derivative', result: 1 },
+    });
+
+    expect(response.status()).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
   test('home page renders the app shell', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/schema.sql
+++ b/apps/web/schema.sql
@@ -110,6 +110,11 @@ CREATE INDEX IF NOT EXISTS idx_graph_edges_type ON graph_edges(type);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_user ON user_knowledge_states(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_node ON user_knowledge_states(node_id);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_states_source_type ON user_knowledge_states(source_type);
+
+CREATE TABLE IF NOT EXISTS user_quiz_rate_limits (
+  user_id TEXT PRIMARY KEY,
+  next_allowed_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_user ON user_knowledge_evidence(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_node ON user_knowledge_evidence(node_id);
 CREATE INDEX IF NOT EXISTS idx_user_knowledge_evidence_source_type ON user_knowledge_evidence(source_type);

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -28,12 +28,13 @@ export async function GET() {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
+    console.error('Health database check failed:', error);
     return NextResponse.json(
       {
         status: 'degraded',
         mode: 'database',
         database: 'disconnected',
-        error: error instanceof Error ? error.message : 'unknown_error',
+        error: 'database_unavailable',
         duration_ms: Date.now() - startedAt,
         timestamp: new Date().toISOString(),
       },

--- a/apps/web/src/app/api/quiz_result/route.ts
+++ b/apps/web/src/app/api/quiz_result/route.ts
@@ -1,22 +1,41 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getCurrentActor } from '@/lib/auth';
-import { submitDbQuizResult } from '@/lib/knowledge-graph-db';
+import { getCurrentUser } from '@/lib/auth';
+import {
+  QuizRateLimitError,
+  UnknownGraphNodeError,
+  submitDbQuizResult,
+} from '@/lib/knowledge-graph-db';
+
+const MAX_QUIZ_REQUEST_BYTES = 4_096;
+const MAX_NODE_ID_LENGTH = 100;
 
 export async function POST(request: NextRequest) {
-  const user = await getCurrentActor();
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const contentLength = Number(request.headers.get('content-length') ?? '0');
+  if (Number.isFinite(contentLength) && contentLength > MAX_QUIZ_REQUEST_BYTES) {
+    return NextResponse.json({ error: 'Request body is too large' }, { status: 413 });
+  }
 
   try {
-    const body = await request.json();
-    const { node_id, result } = body;
+    const body: unknown = await request.json();
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'JSON object required' }, { status: 400 });
+    }
 
-    if (!node_id || result === undefined) {
+    const { node_id, result } = body as { node_id?: unknown; result?: unknown };
+
+    if (typeof node_id !== 'string' || !node_id.trim() || node_id.length > MAX_NODE_ID_LENGTH || result === undefined) {
       return NextResponse.json(
         { error: 'node_id and result are required' },
         { status: 400 }
       );
     }
 
-    if (![0, 0.5, 1].includes(result)) {
+    if (typeof result !== 'number' || ![0, 0.5, 1].includes(result)) {
       return NextResponse.json(
         { error: 'result must be 0, 0.5, or 1' },
         { status: 400 }
@@ -25,7 +44,7 @@ export async function POST(request: NextRequest) {
 
     const response = await submitDbQuizResult(
       user.id,
-      node_id,
+      node_id.trim(),
       result as 0 | 0.5 | 1
     );
 
@@ -37,6 +56,15 @@ export async function POST(request: NextRequest) {
       propagated_count: response.propagated_count,
     });
   } catch (error) {
+    if (error instanceof QuizRateLimitError) {
+      return NextResponse.json(
+        { error: 'Too many quiz submissions. Try again shortly.' },
+        { status: 429, headers: { 'Retry-After': '2' } }
+      );
+    }
+    if (error instanceof UnknownGraphNodeError) {
+      return NextResponse.json({ error: 'Unknown node_id' }, { status: 400 });
+    }
     console.error('Error in POST /api/quiz_result:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }

--- a/apps/web/src/lib/knowledge-graph-db.ts
+++ b/apps/web/src/lib/knowledge-graph-db.ts
@@ -106,6 +106,20 @@ export type KnowledgeContextExport = {
   prompt_block: string;
 };
 
+export class QuizRateLimitError extends Error {
+  constructor() {
+    super('Quiz submissions are temporarily rate limited.');
+    this.name = 'QuizRateLimitError';
+  }
+}
+
+export class UnknownGraphNodeError extends Error {
+  constructor() {
+    super('The requested graph node does not exist.');
+    this.name = 'UnknownGraphNodeError';
+  }
+}
+
 function ensureGraphDatabase() {
   if (!process.env.DATABASE_URL) {
     throw new Error('Graph database access requires DATABASE_URL to be configured.');
@@ -216,6 +230,22 @@ async function persistUserStates(userId: string, states: UserKnowledgeState[]): 
     `,
     values
   );
+}
+
+async function claimQuizSubmission(userId: string): Promise<void> {
+  const { rows } = await pool.query<{ user_id: string }>(
+    `
+    INSERT INTO user_quiz_rate_limits (user_id, next_allowed_at)
+    VALUES ($1, NOW() + INTERVAL '2 seconds')
+    ON CONFLICT (user_id)
+    DO UPDATE SET next_allowed_at = EXCLUDED.next_allowed_at
+    WHERE user_quiz_rate_limits.next_allowed_at <= NOW()
+    RETURNING user_id;
+    `,
+    [userId]
+  );
+
+  if (rows.length === 0) throw new QuizRateLimitError();
 }
 
 export async function getDbGraphDataForUser(userId: string): Promise<ForceGraphData> {
@@ -351,11 +381,17 @@ export async function submitDbQuizResult(
 
   ensureGraphDatabase();
 
+  await claimQuizSubmission(userId);
+
   const [nodes, edges, states] = await Promise.all([
     getGraphNodes(),
     getGraphEdges(),
     getUserStateMap(userId),
   ]);
+
+  if (!nodes.some((node) => node.id === nodeId)) {
+    throw new UnknownGraphNodeError();
+  }
 
   const now = new Date().toISOString();
   const existingState = states.get(nodeId);


### PR DESCRIPTION
## What changed

- require an authenticated user and validate bounded quiz API input
- add an atomic, database-backed per-user quiz submission cooldown
- reject unknown graph node IDs before graph processing
- remove database error details from the public health response
- add browser coverage for unauthenticated quiz submission

## Why

The public quiz endpoint allowed anonymous requests to trigger full graph and database work. The health endpoint returned internal database errors to clients.

## Validation

- `pnpm check`
- `pnpm browser:smoke` (20 passed)
- `pnpm harness:deploy`
- `git diff --check`