### PR TITLE
Patch image parser denial of service

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint and Typecheck
         run: pnpm turbo check
 
+      - name: Verify patched image parser
+        run: pnpm verify:image-size-hardening
+
       - name: Build mobile bundles
         run: pnpm --filter @stem-brain/mobile build
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "smoke": "pnpm --filter @stem-brain/web smoke",
     "browser:smoke": "playwright test",
     "browser:smoke:headed": "playwright test --headed",
+    "verify:image-size-hardening": "node scripts/verify-image-size-hardening.mjs",
     "harness": "pnpm harness:local",
     "harness:local": "pnpm check && pnpm --filter @stem-brain/web check:env:examples && pnpm --filter @stem-brain/web build",
     "harness:browser": "pnpm harness:local && pnpm browser:smoke",
@@ -48,6 +49,9 @@
       "metro>ws": "^7.5.13",
       "react-devtools-core>ws": "^7.5.13",
       "uuid": "^11.1.1"
+    },
+    "patchedDependencies": {
+      "image-size@1.2.1": "patches/image-size@1.2.1.patch"
     }
   }
 }

--- a/patches/image-size@1.2.1.patch
+++ b/patches/image-size@1.2.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/types/icns.js b/dist/types/icns.js
+index f2bfafef3723cb423b110304815e56e3f97f81e0..042889cbe75ce78af0a38540a182be5e862b0330 100644
+--- a/dist/types/icns.js
++++ b/dist/types/icns.js
+@@ -82,6 +82,9 @@ exports.ICNS = {
+         let imageOffset = SIZE_HEADER;
+         let imageHeader = readImageHeader(input, imageOffset);
+         let imageSize = getImageSize(imageHeader[0]);
++        if (imageHeader[1] < SIZE_HEADER) {
++            throw new TypeError('Invalid ICNS image entry length');
++        }
+         imageOffset += imageHeader[1];
+         if (imageOffset === fileLength)
+             return imageSize;
+@@ -93,6 +96,9 @@ exports.ICNS = {
+         while (imageOffset < fileLength && imageOffset < inputLength) {
+             imageHeader = readImageHeader(input, imageOffset);
+             imageSize = getImageSize(imageHeader[0]);
++            if (imageHeader[1] < SIZE_HEADER) {
++                throw new TypeError('Invalid ICNS image entry length');
++            }
+             imageOffset += imageHeader[1];
+             result.images.push(imageSize);
+         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,11 @@ overrides:
   react-devtools-core>ws: ^7.5.13
   uuid: ^11.1.1
 
+patchedDependencies:
+  image-size@1.2.1:
+    hash: dymfgv33nzoat7vtw4f2ejvlfq
+    path: patches/image-size@1.2.1.patch
+
 importers:
 
   .:
@@ -13359,7 +13364,7 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@1.2.1:
+  image-size@1.2.1(patch_hash=dymfgv33nzoat7vtw4f2ejvlfq):
     dependencies:
       queue: 6.0.2
 
@@ -14109,7 +14114,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.35.0
-      image-size: 1.2.1
+      image-size: 1.2.1(patch_hash=dymfgv33nzoat7vtw4f2ejvlfq)
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
@@ -14155,7 +14160,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.36.1
-      image-size: 1.2.1
+      image-size: 1.2.1(patch_hash=dymfgv33nzoat7vtw4f2ejvlfq)
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4

--- a/scripts/verify-image-size-hardening.mjs
+++ b/scripts/verify-image-size-hardening.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const requireFromMobile = createRequire(resolve('apps/mobile/package.json'));
+const imageSize = requireFromMobile('image-size');
+
+function assertRejectedPromptly(name, input) {
+  const startedAt = performance.now();
+  assert.throws(() => imageSize(input), /Invalid|unsupported/);
+  assert.ok(
+    performance.now() - startedAt < 100,
+    `${name} must reject malformed input without blocking the event loop`,
+  );
+}
+
+const malformedIcns = Buffer.alloc(16);
+malformedIcns.write('icns', 0);
+malformedIcns.writeUInt32BE(16, 4);
+malformedIcns.write('ic07', 8);
+// A zero-sized entry caused the ICNS parser's image offset never to advance.
+malformedIcns.writeUInt32BE(0, 12);
+assertRejectedPromptly('ICNS', malformedIcns);
+
+const malformedJxl = Buffer.alloc(16);
+malformedJxl.write('JXL ', 4);
+// A zero-sized ISO-BMFF box previously caused findBox() not to advance.
+malformedJxl.writeUInt32BE(0, 0);
+assertRejectedPromptly('JXL', malformedJxl);
+
+const png = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+]);
+assert.deepEqual(imageSize(png), { width: 1, height: 1, type: 'png' });
+
+console.log('image-size hardening verification passed');


### PR DESCRIPTION
## Summary
- apply a reproducible pnpm patch to reject malformed zero-length ICNS entries before they can stall the parser
- retain the upstream zero-size ISO-BMFF guard already present for JXL/HEIF parsing
- add a regression verifier and run it in Quality Checks

## Root cause
image-size 1.2.1 is pulled in by Expo/Metro. A crafted ICNS entry with a zero length never advanced the parser offset; the JXL/HEIF zero-box guard is already present in this release but npm audit still groups both advisories under its unpatched package range.

## Validation
- pnpm install --frozen-lockfile
- pnpm verify:image-size-hardening
- pnpm --filter @stem-brain/mobile build
- pnpm check

The npm advisory metadata currently has no patched release (`<0.0.0`), so `pnpm audit --prod` will continue to label the two advisories despite the executable regression cases passing.