### PR TITLE
Expire closed pull request previews

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,41 @@
+name: Expire closed pull request previews
+
+on:
+  schedule:
+    # Scheduled workflows run from the default branch. This bounds preview
+    # lifetime without retaining a long-running job for every closed PR.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report eligible Preview deletions without deleting versions
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# This is deliberately separate from deploy-cloudflare.yml so a scheduled
+# cleanup can never cancel a production migration or deployment.
+concurrency:
+  group: preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Expire eligible Preview versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Expire eligible Preview versions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIEW_CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: node scripts/cleanup-pr-previews.mjs

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -6,10 +6,21 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Runs on the default branch. This bounds preview lifetime without retaining
+    # a long-running GitHub Actions job for every closed pull request.
+    - cron: '17 */6 * * *'
   workflow_dispatch:
+    inputs:
+      preview_cleanup_dry_run:
+        description: Report eligible Preview deletions without deleting versions
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Prevent an older commit from deploying after a newer push to the same PR or main.
 concurrency:
@@ -20,6 +31,7 @@ jobs:
   ci:
     name: Quality Checks
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -243,3 +255,22 @@ jobs:
         run: pnpm smoke
         env:
           SMOKE_BASE_URL: ${{ vars.APP_BASE_URL }}
+
+  cleanup_preview_versions:
+    name: Expire closed pull request previews
+    runs-on: ubuntu-latest
+    # Scheduled runs use main. Manual runs default to dry-run so an operator can
+    # inspect eligibility before requesting a live cleanup.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Expire eligible Preview versions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIEW_CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.preview_cleanup_dry_run || false }}
+        run: node scripts/cleanup-pr-previews.mjs

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -6,21 +6,10 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # Runs on the default branch. This bounds preview lifetime without retaining
-    # a long-running GitHub Actions job for every closed pull request.
-    - cron: '17 */6 * * *'
   workflow_dispatch:
-    inputs:
-      preview_cleanup_dry_run:
-        description: Report eligible Preview deletions without deleting versions
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
-  pull-requests: read
 
 # Prevent an older commit from deploying after a newer push to the same PR or main.
 concurrency:
@@ -31,7 +20,6 @@ jobs:
   ci:
     name: Quality Checks
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -255,22 +243,3 @@ jobs:
         run: pnpm smoke
         env:
           SMOKE_BASE_URL: ${{ vars.APP_BASE_URL }}
-
-  cleanup_preview_versions:
-    name: Expire closed pull request previews
-    runs-on: ubuntu-latest
-    # Scheduled runs use main. Manual runs default to dry-run so an operator can
-    # inspect eligibility before requesting a live cleanup.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Expire eligible Preview versions
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PREVIEW_CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.preview_cleanup_dry_run || false }}
-        run: node scripts/cleanup-pr-previews.mjs

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -60,3 +60,4 @@ from the current production schema before enabling preview deploys.
 - Merge to `main`: quality checks, Drizzle migrations, production deploy, then smoke test.
 - Fork PRs receive quality checks but no preview because repository secrets are not exposed to them.
 - Preview URLs are public `workers.dev` URLs unless Cloudflare Access is applied in the dashboard.
+- Preview cleanup runs every six hours. It deletes versions only after their PR is closed: 24 hours after a merge, or 7 days after an unmerged close. A reopened/open PR is retained. Run the workflow manually with its dry-run input before an ad-hoc cleanup.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ Pull requests automatically receive a Cloudflare Worker preview. Its stable addr
 `https://pr-<number>-girapphe-preview.<workers-subdomain>.workers.dev`; it uses preview
 Clerk keys and an isolated Neon database.
 
+Preview retention is automatic: merged PR previews remain available for 24 hours, and
+closed-but-unmerged previews remain for 7 days. A six-hour cleanup job then removes their
+Cloudflare Worker versions. Reopened PRs are never removed while open.
+
 GitHub Actions deployment details and required secrets are documented in:
 - `DEPLOY.md`
 - `ENVIRONMENTS.md`

--- a/scripts/cleanup-pr-previews.mjs
+++ b/scripts/cleanup-pr-previews.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const CLEANUP_POLICY = {
+  // Keeps a just-merged Preview available for a short verification window.
+  mergedHours: 24,
+  // Allows authors time to reopen an accidentally closed, unmerged PR.
+  closedDays: 7,
+};
+
+const required = [
+  'GITHUB_REPOSITORY',
+  'GITHUB_TOKEN',
+  'CLOUDFLARE_API_TOKEN',
+  'CLOUDFLARE_ACCOUNT_ID',
+];
+
+for (const key of required) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
+const repository = process.env.GITHUB_REPOSITORY;
+const cloudflareAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const cloudflareToken = process.env.CLOUDFLARE_API_TOKEN;
+const workerName = process.env.PREVIEW_WORKER_NAME ?? 'girapphe-preview';
+const dryRun = process.env.PREVIEW_CLEANUP_DRY_RUN === 'true';
+const now = Date.now();
+
+async function request(url, options = {}) {
+  const response = await fetch(url, options);
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok || payload?.success === false) {
+    const detail = payload?.errors?.map((error) => error.message).join('; ') || response.statusText;
+    throw new Error(`${options.method ?? 'GET'} ${url} failed (${response.status}): ${detail}`);
+  }
+
+  return payload;
+}
+
+async function listPreviewVersions() {
+  const versions = [];
+  let page = 1;
+
+  while (true) {
+    const url = new URL(
+      `https://api.cloudflare.com/client/v4/accounts/${cloudflareAccountId}/workers/scripts/${workerName}/versions`
+    );
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('per_page', '100');
+
+    const payload = await request(url, {
+      headers: { Authorization: `Bearer ${cloudflareToken}` },
+    });
+    versions.push(...(payload.result ?? []));
+
+    const totalPages = payload.result_info?.total_pages ?? page;
+    if (page >= totalPages) return versions;
+    page += 1;
+  }
+}
+
+function getPreviewPullNumber(version) {
+  const annotations = version.metadata?.annotations ?? version.annotations ?? {};
+  const message = annotations['workers/message'] ?? version.metadata?.message ?? version.message ?? '';
+  const match = /^PR #(\d+)$/.exec(message.trim());
+  return match ? Number(match[1]) : null;
+}
+
+async function getPullRequest(number) {
+  const payload = await request(`https://api.github.com/repos/${repository}/pulls/${number}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  return payload;
+}
+
+function getEligibleAt(pullRequest) {
+  if (pullRequest.state !== 'closed') return null;
+
+  const closedAt = pullRequest.merged_at ?? pullRequest.closed_at;
+  if (!closedAt) return null;
+
+  const closedTime = Date.parse(closedAt);
+  if (Number.isNaN(closedTime)) return null;
+
+  const retentionMs = pullRequest.merged_at
+    ? CLEANUP_POLICY.mergedHours * 60 * 60 * 1000
+    : CLEANUP_POLICY.closedDays * 24 * 60 * 60 * 1000;
+
+  return closedTime + retentionMs;
+}
+
+async function deleteVersion(versionId) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${cloudflareAccountId}/workers/workers/${workerName}/versions/${versionId}`;
+  await request(url, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${cloudflareToken}` },
+  });
+}
+
+const versions = await listPreviewVersions();
+const versionsByPullRequest = new Map();
+
+for (const version of versions) {
+  const pullNumber = getPreviewPullNumber(version);
+  if (!pullNumber || !version.id) continue;
+
+  const matchingVersions = versionsByPullRequest.get(pullNumber) ?? [];
+  matchingVersions.push(version);
+  versionsByPullRequest.set(pullNumber, matchingVersions);
+}
+
+let deleted = 0;
+let skipped = 0;
+
+for (const [pullNumber, pullVersions] of versionsByPullRequest) {
+  const pullRequest = await getPullRequest(pullNumber);
+  const eligibleAt = getEligibleAt(pullRequest);
+
+  if (!eligibleAt || eligibleAt > now) {
+    skipped += pullVersions.length;
+    continue;
+  }
+
+  const reason = pullRequest.merged_at
+    ? `merged more than ${CLEANUP_POLICY.mergedHours}h ago`
+    : `closed more than ${CLEANUP_POLICY.closedDays}d ago`;
+
+  for (const version of pullVersions) {
+    if (dryRun) {
+      console.log(`[dry-run] Would delete Preview version ${version.id} for PR #${pullNumber} (${reason}).`);
+      continue;
+    }
+
+    await deleteVersion(version.id);
+    deleted += 1;
+    console.log(`Deleted Preview version ${version.id} for PR #${pullNumber} (${reason}).`);
+  }
+}
+
+console.log(
+  `Preview cleanup complete: ${dryRun ? 'dry-run, ' : ''}${deleted} deleted, ${skipped} retained, ${versions.length} versions inspected.`
+);


### PR DESCRIPTION
## Summary

- Adds a six-hour Cloudflare Worker Preview cleanup sweep.
- Retains merged previews for 24 hours and unmerged closed previews for 7 days.
- Protects open or reopened pull requests and supports manual dry-run validation.

## Why

Preview aliases are persistent in Cloudflare and were not previously cleaned after a pull request closed.

## Validation

- node --check scripts/cleanup-pr-previews.mjs
- Workflow YAML parsed with js-yaml
- pnpm harness