### PR TITLE
feat(web): group concepts by domain and tag

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -262,10 +262,31 @@ test.describe('browser smoke', () => {
     const conceptsTab = page.getByRole('link', { name: 'Concepts' });
     await expect(conceptsTab).toHaveAttribute('aria-current', 'page');
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
+
+    const groupBy = page.getByLabel('Group by');
+    await expect(groupBy).toHaveValue('domain');
+    expect(await page.getByTestId('concept-group').count(), 'domain sections render by default').toBeGreaterThan(1);
+
+    const domainCardIds = await page.getByTestId('concept-card').evaluateAll((cards) => (
+      cards.map((card) => card.getAttribute('data-concept-id')).filter(Boolean)
+    ));
+    expect(new Set(domainCardIds).size, 'domain grouping does not duplicate multi-domain cards').toBe(domainCardIds.length);
+    const visibleCardCount = domainCardIds.length;
+
+    await groupBy.selectOption('tag');
+    await expect(page.getByRole('heading', { name: 'Untagged', exact: true })).toBeVisible();
+    expect(await page.getByTestId('concept-card').count(), 'tag grouping keeps tagless public concepts visible').toBe(visibleCardCount);
+
+    await groupBy.selectOption('none');
+    await expect(page.getByTestId('concept-grid')).toBeVisible();
+    await expect(page.getByTestId('concept-group')).toHaveCount(0);
+
     const sort = page.getByLabel('Sort concepts');
     await expect(sort).toHaveValue('newest');
-    await sort.selectOption('updated');
-    await expect(sort).toHaveValue('updated');
+    await sort.selectOption('title');
+    await expect(sort).toHaveValue('title');
+    const titles = await page.getByTestId('concept-card').locator('h3').allTextContents();
+    expect(titles).toEqual([...titles].sort((a, b) => a.localeCompare(b)));
 
     const filters = page.locator('summary').filter({ hasText: 'Filters' });
     await filters.click();
@@ -280,6 +301,7 @@ test.describe('browser smoke', () => {
     expect((filterPanel?.x ?? 0) + (filterPanel?.width ?? 0), 'filter panel right edge').toBeLessThanOrEqual(viewport?.width ?? 0);
     await page.getByRole('button', { name: 'Reset all' }).click();
     await expect(sort).toHaveValue('newest');
+    await expect(groupBy).toHaveValue('domain');
     await expect(addedWithin).toHaveValue('all');
     await filters.click();
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "check": "pnpm lint && pnpm typecheck && pnpm test:server && pnpm test:error-recovery && pnpm test:localization && pnpm check:worker-types",
-    "test:server": "NODE_ENV=test NODE_OPTIONS=--conditions=react-server tsx --test src/app/api/mcp/*.test.ts src/lib/mcp/*.test.ts src/lib/env-validation.test.ts src/lib/ops/*.test.ts src/lib/knowledge-ingestion.test.ts src/lib/knowledge-map-time.test.ts src/lib/practice-ad-schedule.test.ts src/lib/private-practice-cards.test.ts src/lib/stabilization.test.ts src/lib/billing/*.test.ts src/components/draft-review-selection.test.ts",
+    "test:server": "NODE_ENV=test NODE_OPTIONS=--conditions=react-server tsx --test src/app/api/mcp/*.test.ts src/lib/mcp/*.test.ts src/lib/env-validation.test.ts src/lib/ops/*.test.ts src/lib/knowledge-ingestion.test.ts src/lib/knowledge-map-grouping.test.ts src/lib/knowledge-map-time.test.ts src/lib/practice-ad-schedule.test.ts src/lib/private-practice-cards.test.ts src/lib/stabilization.test.ts src/lib/billing/*.test.ts src/components/draft-review-selection.test.ts",
     "test:error-recovery": "tsx --test src/app/error.test.tsx",
     "test:knowledge-ingestion": "pnpm test:server",
     "env:setup:dev": "bash ../../scripts/setup-dev-env.sh",

--- a/apps/web/src/components/knowledge-map.tsx
+++ b/apps/web/src/components/knowledge-map.tsx
@@ -11,10 +11,14 @@ import ConfirmDeleteButton from '@/components/confirm-delete-button';
 import type { KnowledgeLinkTarget } from '@/actions/knowledge-ingestion-actions';
 import {
   isWithinAddedDateRangeOrUndated,
-  sortConceptCards,
   type AddedDateRange,
   type ConceptSort,
 } from '@/lib/knowledge-map-time';
+import {
+  groupConceptCards,
+  UNTAGGED_CONCEPT_GROUP_KEY,
+  type ConceptGroupBy,
+} from '@/lib/knowledge-map-grouping';
 import type { Locale } from '@stem-brain/shared';
 import { useI18n } from '@/i18n/client';
 
@@ -100,13 +104,14 @@ export default function KnowledgeMap({
   const [selectedStatus, setSelectedStatus] = useState<CardStatus | 'all' | 'unstarted'>('all');
   const [addedDateRange, setAddedDateRange] = useState<AddedDateRange>('all');
   const [sort, setSort] = useState<ConceptSort>('newest');
+  const [groupBy, setGroupBy] = useState<ConceptGroupBy>('domain');
   const [viewMode, setViewMode] = useState<'grid' | 'graph'>(initialView);
   const [includeGenerated, setIncludeGenerated] = useState(false);
   const [generatedLimit, setGeneratedLimit] = useState(250);
   const [generatedCards, setGeneratedCards] = useState<(KnowledgeCard & { status: CardStatus | null })[] | null>(null);
   const [loadingGenerated, setLoadingGenerated] = useState(false);
   const [generatedError, setGeneratedError] = useState<string | null>(null);
-  const { t } = useI18n();
+  const { t, formatNumber } = useI18n();
 
   useEffect(() => {
     if (isGuest) return;
@@ -308,7 +313,10 @@ export default function KnowledgeMap({
     });
   }, [addedDateRange, cards, filter, selectedDomain, selectedStatus]);
 
-  const sortedCards = useMemo(() => sortConceptCards(filteredCards, sort), [filteredCards, sort]);
+  const cardGroups = useMemo(
+    () => groupConceptCards(filteredCards, groupBy, sort),
+    [filteredCards, groupBy, sort]
+  );
 
   const activeFilterCount = Number(selectedDomain !== 'all')
     + Number(selectedStatus !== 'all')
@@ -371,6 +379,20 @@ export default function KnowledgeMap({
                   <option value="newest">{t('knowledge.sortNewest')}</option>
                   <option value="updated">{t('knowledge.sortUpdated')}</option>
                   <option value="title">{t('knowledge.sortTitle')}</option>
+                </select>
+              </div>
+
+              <div>
+                <select
+                  id="concept-group-by"
+                  aria-label={t('knowledge.groupBy')}
+                  value={groupBy}
+                  onChange={(e) => setGroupBy(e.target.value as ConceptGroupBy)}
+                  className="rounded border bg-white p-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                  <option value="domain">{t('knowledge.groupByDomain')}</option>
+                  <option value="tag">{t('knowledge.groupByTag')}</option>
+                  <option value="none">{t('knowledge.groupByNone')}</option>
                 </select>
               </div>
 
@@ -470,6 +492,7 @@ export default function KnowledgeMap({
                         setSelectedStatus('all');
                         setAddedDateRange('all');
                         setSort('newest');
+                        setGroupBy('domain');
                         setIncludeGenerated(false);
                         setGeneratedCards(null);
                         setGeneratedError(null);
@@ -503,11 +526,46 @@ export default function KnowledgeMap({
           </div>
 
           <div>
-            <div data-testid="concept-grid" className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-              {sortedCards.map((card) => (
-                <KnowledgeCardItem key={card.id} card={card} />
-              ))}
-            </div>
+            {groupBy === 'tag' ? (
+              <p className="mb-5 text-sm text-gray-600">{t('knowledge.tagGroupingHint')}</p>
+            ) : null}
+
+            {groupBy === 'none' ? (
+              <ConceptCardGrid cards={cardGroups[0]?.cards ?? []} testId="concept-grid" />
+            ) : (
+              <div data-testid="concept-groups" className="space-y-10">
+                {cardGroups.map((group, index) => {
+                  const heading = groupBy === 'domain'
+                    ? formatDomainLabel(group.key)
+                    : group.key === UNTAGGED_CONCEPT_GROUP_KEY
+                      ? t('knowledge.untagged')
+                      : `#${group.key}`;
+                  const headingId = `concept-group-${index}`;
+
+                  return (
+                    <section
+                      key={group.key}
+                      data-testid="concept-group"
+                      data-group-key={group.key}
+                      aria-labelledby={headingId}
+                    >
+                      <div className="mb-4 flex items-center gap-2 border-b pb-2">
+                        <h2 id={headingId} className="text-xl font-semibold text-gray-700">
+                          {heading}
+                        </h2>
+                        <span
+                          className="rounded-full bg-gray-200 px-2 py-0.5 text-xs font-semibold text-gray-600"
+                          aria-label={t('knowledge.groupCount', { count: group.cards.length })}
+                        >
+                          {formatNumber(group.cards.length)}
+                        </span>
+                      </div>
+                      <ConceptCardGrid cards={group.cards} />
+                    </section>
+                  );
+                })}
+              </div>
+            )}
 
             {filteredCards.length === 0 && (
               <div className="text-center py-12 text-gray-600">
@@ -517,6 +575,16 @@ export default function KnowledgeMap({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function ConceptCardGrid({ cards, testId }: { cards: MapCard[]; testId?: string }) {
+  return (
+    <div data-testid={testId} className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {cards.map((card) => (
+        <KnowledgeCardItem key={card.id} card={card} />
+      ))}
     </div>
   );
 }
@@ -540,7 +608,11 @@ function KnowledgeCardItem({ card }: { card: MapCard }) {
   };
 
   return (
-    <div data-testid="concept-card" className={`p-4 rounded-lg border shadow-sm transition-all hover:shadow-md ${getStatusColor(card.status)}`}>
+    <div
+      data-testid="concept-card"
+      data-concept-id={card.id}
+      className={`p-4 rounded-lg border shadow-sm transition-all hover:shadow-md ${getStatusColor(card.status)}`}
+    >
       <div className="flex justify-between items-start mb-2">
         <span className="text-xs tracking-wider text-gray-700 font-semibold">
           {card.isPersonal

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -365,6 +365,16 @@ export const AR_MESSAGES = {
   "knowledge.sortNewest": "الأحدث أولًا",
   "knowledge.sortUpdated": "المعدّل حديثًا",
   "knowledge.sortTitle": "العنوان أ–ي",
+  "knowledge.groupBy": "تجميع حسب",
+  "knowledge.groupByDomain": "المجال",
+  "knowledge.groupByTag": "الوسم",
+  "knowledge.groupByNone": "من دون تجميع",
+  "knowledge.untagged": "من دون وسم",
+  "knowledge.groupCount": {
+    "one": "{count} مفهوم",
+    "other": "{count} مفاهيم"
+  },
+  "knowledge.tagGroupingHint": "تنظّم الوسوم المخصصة المفاهيم الخاصة؛ وتظهر المفاهيم العامة بلا وسوم ضمن «من دون وسم».",
   "knowledge.addedWithin": "أُضيف خلال",
   "knowledge.allTime": "كل الوقت",
   "knowledge.today": "اليوم",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -365,6 +365,16 @@ export const EN_MESSAGES = {
   "knowledge.sortNewest": "Newest first",
   "knowledge.sortUpdated": "Recently updated",
   "knowledge.sortTitle": "Title A–Z",
+  "knowledge.groupBy": "Group by",
+  "knowledge.groupByDomain": "Domain",
+  "knowledge.groupByTag": "Tag",
+  "knowledge.groupByNone": "None",
+  "knowledge.untagged": "Untagged",
+  "knowledge.groupCount": {
+    "one": "{count} concept",
+    "other": "{count} concepts"
+  },
+  "knowledge.tagGroupingHint": "Custom tags organize private concepts; public concepts without tags appear under Untagged.",
   "knowledge.addedWithin": "Added within",
   "knowledge.allTime": "All time",
   "knowledge.today": "Today",

--- a/apps/web/src/i18n/catalogs/es.ts
+++ b/apps/web/src/i18n/catalogs/es.ts
@@ -365,6 +365,16 @@ export const ES_MESSAGES = {
   "knowledge.sortNewest": "Más recientes primero",
   "knowledge.sortUpdated": "Actualizados recientemente",
   "knowledge.sortTitle": "Título A–Z",
+  "knowledge.groupBy": "Agrupar por",
+  "knowledge.groupByDomain": "Campo",
+  "knowledge.groupByTag": "Etiqueta",
+  "knowledge.groupByNone": "Sin agrupar",
+  "knowledge.untagged": "Sin etiqueta",
+  "knowledge.groupCount": {
+    "one": "{count} concepto",
+    "other": "{count} conceptos"
+  },
+  "knowledge.tagGroupingHint": "Las etiquetas personalizadas organizan conceptos privados; los conceptos públicos sin etiquetas aparecen en «Sin etiqueta».",
   "knowledge.addedWithin": "Añadido en los últimos",
   "knowledge.allTime": "Todo el tiempo",
   "knowledge.today": "Hoy",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -365,6 +365,16 @@ export const HI_MESSAGES = {
   "knowledge.sortNewest": "नवीनतम पहले",
   "knowledge.sortUpdated": "हाल में बदले गए",
   "knowledge.sortTitle": "शीर्षक अ–ज़",
+  "knowledge.groupBy": "इसके अनुसार समूहित करें",
+  "knowledge.groupByDomain": "क्षेत्र",
+  "knowledge.groupByTag": "टैग",
+  "knowledge.groupByNone": "समूहित न करें",
+  "knowledge.untagged": "बिना टैग",
+  "knowledge.groupCount": {
+    "one": "{count} अवधारणा",
+    "other": "{count} अवधारणाएँ"
+  },
+  "knowledge.tagGroupingHint": "कस्टम टैग निजी अवधारणाओं को व्यवस्थित करते हैं; बिना टैग वाली सार्वजनिक अवधारणाएँ “बिना टैग” में दिखाई देती हैं।",
   "knowledge.addedWithin": "इस अवधि में जोड़े गए",
   "knowledge.allTime": "सभी समय",
   "knowledge.today": "आज",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -352,6 +352,15 @@ export const JA_MESSAGES = {
   "knowledge.sortNewest": "新しい順",
   "knowledge.sortUpdated": "最近更新",
   "knowledge.sortTitle": "タイトル順",
+  "knowledge.groupBy": "グループ化",
+  "knowledge.groupByDomain": "分野",
+  "knowledge.groupByTag": "タグ",
+  "knowledge.groupByNone": "グループ化なし",
+  "knowledge.untagged": "タグなし",
+  "knowledge.groupCount": {
+    "other": "{count}件の概念"
+  },
+  "knowledge.tagGroupingHint": "カスタムタグでは非公開の概念を整理します。タグのない公開概念は「タグなし」に表示されます。",
   "knowledge.addedWithin": "追加された期間",
   "knowledge.allTime": "すべて",
   "knowledge.today": "今日",

--- a/apps/web/src/i18n/catalogs/zh-CN.ts
+++ b/apps/web/src/i18n/catalogs/zh-CN.ts
@@ -365,6 +365,15 @@ export const ZH_CN_MESSAGES = {
   "knowledge.sortNewest": "最新优先",
   "knowledge.sortUpdated": "最近更新",
   "knowledge.sortTitle": "标题 A–Z",
+  "knowledge.groupBy": "分组方式",
+  "knowledge.groupByDomain": "领域",
+  "knowledge.groupByTag": "标签",
+  "knowledge.groupByNone": "不分组",
+  "knowledge.untagged": "无标签",
+  "knowledge.groupCount": {
+    "other": "{count} 个概念"
+  },
+  "knowledge.tagGroupingHint": "自定义标签用于整理私有概念；没有标签的公开概念会显示在“无标签”下。",
   "knowledge.addedWithin": "添加于最近",
   "knowledge.allTime": "全部时间",
   "knowledge.today": "今天",

--- a/apps/web/src/lib/knowledge-map-grouping.test.ts
+++ b/apps/web/src/lib/knowledge-map-grouping.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  FLAT_CONCEPT_GROUP_KEY,
+  UNTAGGED_CONCEPT_GROUP_KEY,
+  groupConceptCards,
+} from './knowledge-map-grouping';
+
+type TestCard = {
+  id: string;
+  title: string;
+  domain?: string;
+  domains?: string[];
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+function cardIdsByGroup(groups: ReturnType<typeof groupConceptCards<TestCard>>) {
+  return Object.fromEntries(groups.map((group) => [
+    group.key,
+    group.cards.map((card) => card.id),
+  ]));
+}
+
+test('groups each card by only its first non-empty domain or tag', () => {
+  const cards: TestCard[] = [
+    { id: 'multi', title: 'Multi', domain: 'fallback', domains: ['math', 'physics'], tags: ['bayes', 'probability'] },
+    { id: 'physics', title: 'Physics', domain: 'physics', domains: ['physics'], tags: ['probability'] },
+    { id: 'blank-first', title: 'Blank first', domain: 'fallback', domains: [' ', 'chemistry'], tags: [' ', 'ml'] },
+    { id: 'domain-fallback', title: 'Fallback', domain: 'biology', domains: [], tags: [] },
+    { id: 'other-fallback', title: 'Other', domains: [], tags: [] },
+  ];
+
+  const domainGroups = groupConceptCards(cards, 'domain', 'title');
+  assert.deepEqual(domainGroups.map((group) => group.key), ['biology', 'chemistry', 'math', 'other', 'physics']);
+  assert.deepEqual(cardIdsByGroup(domainGroups), {
+    biology: ['domain-fallback'],
+    chemistry: ['blank-first'],
+    math: ['multi'],
+    other: ['other-fallback'],
+    physics: ['physics'],
+  });
+
+  const tagGroups = groupConceptCards(cards, 'tag', 'title');
+  assert.deepEqual(cardIdsByGroup(tagGroups), {
+    bayes: ['multi'],
+    ml: ['blank-first'],
+    probability: ['physics'],
+    [UNTAGGED_CONCEPT_GROUP_KEY]: ['domain-fallback', 'other-fallback'],
+  });
+});
+
+test('orders group keys alphabetically with the untagged group last', () => {
+  const cards: TestCard[] = [
+    { id: 'untagged', title: 'Untagged', tags: [] },
+    { id: 'zeta', title: 'Zeta', tags: ['zeta'] },
+    { id: 'alpha', title: 'Alpha', tags: ['alpha'] },
+  ];
+
+  assert.deepEqual(
+    groupConceptCards(cards, 'tag', 'title').map((group) => group.key),
+    ['alpha', 'zeta', UNTAGGED_CONCEPT_GROUP_KEY],
+  );
+});
+
+test('sorts cards independently within each group using the requested concept sort', () => {
+  const cards: TestCard[] = [
+    { id: 'math-old', title: 'Zeta', domain: 'math', createdAt: '2026-08-01T00:00:00.000Z' },
+    { id: 'physics-old', title: 'Beta', domain: 'physics', createdAt: '2026-08-02T00:00:00.000Z' },
+    { id: 'math-new', title: 'Alpha', domain: 'math', createdAt: '2026-08-20T00:00:00.000Z' },
+    { id: 'physics-new', title: 'Gamma', domain: 'physics', createdAt: '2026-08-19T00:00:00.000Z' },
+  ];
+
+  assert.deepEqual(cardIdsByGroup(groupConceptCards(cards, 'domain', 'newest')), {
+    math: ['math-new', 'math-old'],
+    physics: ['physics-new', 'physics-old'],
+  });
+  assert.deepEqual(cardIdsByGroup(groupConceptCards(cards, 'domain', 'title')), {
+    math: ['math-new', 'math-old'],
+    physics: ['physics-old', 'physics-new'],
+  });
+});
+
+test('returns one sorted flat group when grouping is disabled', () => {
+  const cards: TestCard[] = [
+    { id: 'zeta', title: 'Zeta', domain: 'math' },
+    { id: 'alpha', title: 'Alpha', domain: 'physics' },
+  ];
+
+  assert.deepEqual(groupConceptCards(cards, 'none', 'title'), [{
+    key: FLAT_CONCEPT_GROUP_KEY,
+    cards: [cards[1], cards[0]],
+  }]);
+  assert.deepEqual(groupConceptCards([], 'none', 'title'), [{
+    key: FLAT_CONCEPT_GROUP_KEY,
+    cards: [],
+  }]);
+});
+
+test('does not mutate the input array or nested taxonomy arrays', () => {
+  const cards: TestCard[] = [
+    { id: 'zeta', title: 'Zeta', domain: 'math', domains: ['math', 'physics'], tags: ['zeta', 'secondary'] },
+    { id: 'alpha', title: 'Alpha', domain: 'math', domains: ['math'], tags: ['alpha'] },
+  ];
+  const snapshot = structuredClone(cards);
+
+  groupConceptCards(cards, 'domain', 'title');
+  groupConceptCards(cards, 'tag', 'newest');
+  groupConceptCards(cards, 'none', 'title');
+
+  assert.deepEqual(cards, snapshot);
+});

--- a/apps/web/src/lib/knowledge-map-grouping.ts
+++ b/apps/web/src/lib/knowledge-map-grouping.ts
@@ -1,0 +1,70 @@
+import {
+  sortConceptCards,
+  type ConceptSort,
+  type SortableConceptCard,
+} from './knowledge-map-time';
+
+export type ConceptGroupBy = 'domain' | 'tag' | 'none';
+
+export const UNTAGGED_CONCEPT_GROUP_KEY = '__untagged__';
+export const FLAT_CONCEPT_GROUP_KEY = '__all__';
+
+export type GroupableConceptCard = SortableConceptCard & {
+  domain?: string | null;
+  domains?: readonly (string | null | undefined)[] | null;
+  tags?: readonly (string | null | undefined)[] | null;
+};
+
+export type ConceptCardGroup<T extends GroupableConceptCard> = {
+  key: string;
+  cards: T[];
+};
+
+function firstNonEmpty(values: readonly (string | null | undefined)[] | null | undefined) {
+  for (const value of values ?? []) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+
+  return undefined;
+}
+
+function getGroupKey(card: GroupableConceptCard, groupBy: Exclude<ConceptGroupBy, 'none'>) {
+  if (groupBy === 'tag') {
+    return firstNonEmpty(card.tags) ?? UNTAGGED_CONCEPT_GROUP_KEY;
+  }
+
+  return firstNonEmpty(card.domains)
+    ?? (typeof card.domain === 'string' && card.domain.trim() ? card.domain.trim() : undefined)
+    ?? 'other';
+}
+
+function compareGroupKeys(a: string, b: string) {
+  if (a === UNTAGGED_CONCEPT_GROUP_KEY) return b === UNTAGGED_CONCEPT_GROUP_KEY ? 0 : 1;
+  if (b === UNTAGGED_CONCEPT_GROUP_KEY) return -1;
+  return a.localeCompare(b);
+}
+
+export function groupConceptCards<T extends GroupableConceptCard>(
+  cards: readonly T[],
+  groupBy: ConceptGroupBy,
+  sort: ConceptSort,
+): ConceptCardGroup<T>[] {
+  if (groupBy === 'none') {
+    return [{ key: FLAT_CONCEPT_GROUP_KEY, cards: sortConceptCards(cards, sort) }];
+  }
+
+  const cardsByGroup = new Map<string, T[]>();
+
+  for (const card of cards) {
+    const key = getGroupKey(card, groupBy);
+    const groupCards = cardsByGroup.get(key);
+
+    if (groupCards) groupCards.push(card);
+    else cardsByGroup.set(key, [card]);
+  }
+
+  return Array.from(cardsByGroup, ([key, groupCards]) => ({
+    key,
+    cards: sortConceptCards(groupCards, sort),
+  })).sort((a, b) => compareGroupKeys(a.key, b.key));
+}

--- a/apps/web/src/lib/knowledge-map-time.test.ts
+++ b/apps/web/src/lib/knowledge-map-time.test.ts
@@ -46,7 +46,7 @@ test('added-date filtering keeps undated static concepts visible', () => {
   assert.equal(isWithinAddedDateRangeOrUndated('2026-08-12T11:59:59.999Z', 'week', now), false);
 });
 
-test('concept sorting is global rather than limited to a domain group', () => {
+test('ungrouped concept sorting follows the selected global order', () => {
   const cards = [
     { title: 'Older mathematics', createdAt: '2026-08-01T12:00:00.000Z', updatedAt: '2026-08-18T12:00:00.000Z' },
     { title: 'Newest physics', createdAt: '2026-08-19T12:00:00.000Z', updatedAt: '2026-08-10T12:00:00.000Z' },
@@ -60,5 +60,9 @@ test('concept sorting is global rather than limited to a domain group', () => {
   assert.deepEqual(
     sortConceptCards(cards, 'updated').map((card) => card.title),
     ['Newest update computer science', 'Older mathematics', 'Newest physics'],
+  );
+  assert.deepEqual(
+    sortConceptCards(cards, 'title').map((card) => card.title),
+    ['Newest physics', 'Newest update computer science', 'Older mathematics'],
   );
 });


### PR DESCRIPTION
## Summary

- add Domain, Tag, and None grouping controls to the Concepts grid, defaulting to Domain
- place each card in its primary domain or tag only, keeping all badges visible and avoiding duplicate cards
- keep tagless public concepts visible in a localized Untagged section
- add all six locale catalogs plus grouping unit coverage and desktop/mobile browser assertions

## Validation

- pnpm harness
- pnpm build:cf
- targeted Concepts Playwright on the local OpenNext Worker: 2 passed (desktop + mobile)
- full local Worker Playwright: 65 passed, 2 skipped; 3 failures were outside this change (practice ad insertion on both projects and pre-hydration recovery on mobile), so deployed Preview CI remains the merge gate

## Scope

Public concepts currently have domain taxonomy but no first-class tags. In Tag mode they remain visible under Untagged; private concepts use their existing custom tags.