### PR TITLE
feat: show private notes in Concepts

### DIFF
--- a/apps/mobile/app/(tabs)/browse.tsx
+++ b/apps/mobile/app/(tabs)/browse.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'expo-router';
+import { useCallback, useMemo, useState } from 'react';
+import { useFocusEffect, useRouter } from 'expo-router';
 import {
   FlatList,
   Pressable,
@@ -20,6 +20,13 @@ import {
   getRelatedNodes,
 } from '@/knowledge';
 import { mobileApi, type CardStatus, type PersonalNoteSummary } from '@/api';
+import {
+  filterPersonalBrowseConcepts,
+  isCurrentPrivateGraphOwner,
+  mergeBrowseConcepts,
+  mergeBrowseDomains,
+  resolveBrowseDomain,
+} from '@/browse-concepts';
 import { useMobileAuth } from '@/auth';
 import { useI18n } from '@/i18n';
 import { normalizeCardNodeId, useLocalizedContent } from '@/localized-content';
@@ -27,6 +34,9 @@ import { localizeDomain, localizeType } from '@stem-brain/shared';
 import { TranslationFallbackNotice } from '@/components/translation-fallback-notice';
 
 const DIFFICULTY_OPTIONS: DifficultyOption[] = ['All', 1, 2, 3, 4, 5];
+const PUBLIC_DOMAINS: DomainOption[] = getDomainOptions();
+const EMPTY_PERSONAL_NOTES: PersonalNoteSummary[] = [];
+const EMPTY_STATUS_BY_NODE_ID = new Map<string, CardStatus | null>();
 
 export default function BrowseScreen() {
   const router = useRouter();
@@ -35,11 +45,19 @@ export default function BrowseScreen() {
   const [query, setQuery] = useState('');
   const [selectedDomain, setSelectedDomain] = useState<DomainOption>('All');
   const [selectedDifficulty, setSelectedDifficulty] = useState<DifficultyOption>('All');
-  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [selectedConceptId, setSelectedConceptId] = useState<string | null>(null);
+  const [selectedPublicNode, setSelectedPublicNode] = useState<GraphNode | null>(null);
   const [statusByNodeId, setStatusByNodeId] = useState<Map<string, CardStatus | null>>(new Map());
   const [personalNotes, setPersonalNotes] = useState<PersonalNoteSummary[]>([]);
+  const [graphOwnerId, setGraphOwnerId] = useState<string | null>(null);
+  const hasCurrentPrivateGraph = isCurrentPrivateGraphOwner(isSignedIn, userId, graphOwnerId);
+  const currentPersonalNotes = hasCurrentPrivateGraph ? personalNotes : EMPTY_PERSONAL_NOTES;
+  const currentStatusByNodeId = hasCurrentPrivateGraph ? statusByNodeId : EMPTY_STATUS_BY_NODE_ID;
 
-  const domains = useMemo(() => getDomainOptions(), []);
+  const domains = useMemo<DomainOption[]>(
+    () => mergeBrowseDomains(PUBLIC_DOMAINS, currentPersonalNotes),
+    [currentPersonalNotes],
+  );
   const candidateNodes = useMemo(
     () =>
       filterNodes({
@@ -49,8 +67,14 @@ export default function BrowseScreen() {
       }),
     [selectedDifficulty, selectedDomain],
   );
-  const localized = useLocalizedContent(candidateNodes.map((node) => node.id), selectedNode?.id ?? candidateNodes[0]?.id);
-  const nodes = useMemo(() => {
+  const selectedPublicNodeId = selectedPublicNode?.id ?? (candidateNodes.some((node) => node.id === selectedConceptId)
+    ? selectedConceptId ?? undefined
+    : undefined);
+  const localized = useLocalizedContent(
+    candidateNodes.map((node) => node.id),
+    selectedPublicNodeId ?? candidateNodes[0]?.id,
+  );
+  const publicNodes = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase(locale);
     if (!normalizedQuery) return candidateNodes;
     return candidateNodes.filter((node) => {
@@ -60,31 +84,68 @@ export default function BrowseScreen() {
         .some((value) => value!.toLocaleLowerCase(locale).includes(normalizedQuery));
     });
   }, [candidateNodes, locale, localized, query]);
-
-  const activeNode = selectedNode ?? nodes[0] ?? null;
+  const visiblePersonalNotes = useMemo(
+    () => filterPersonalBrowseConcepts(currentPersonalNotes, {
+      query,
+      domain: selectedDomain,
+      difficulty: selectedDifficulty,
+      locale,
+    }),
+    [currentPersonalNotes, locale, query, selectedDifficulty, selectedDomain],
+  );
+  const concepts = useMemo(
+    () => mergeBrowseConcepts(publicNodes, visiblePersonalNotes),
+    [publicNodes, visiblePersonalNotes],
+  );
+  const activeConcept = concepts.find((concept) => concept.id === selectedConceptId)
+    ?? (selectedPublicNode
+      ? { kind: 'public' as const, id: selectedPublicNode.id, node: selectedPublicNode }
+      : null)
+    ?? concepts[0]
+    ?? null;
+  const activeNode = activeConcept?.kind === 'public' ? activeConcept.node : null;
+  const activeNote = activeConcept?.kind === 'personal' ? activeConcept.note : null;
   const relatedNodes = useMemo(() => (activeNode ? getRelatedNodes(activeNode.id) : []), [activeNode]);
+
   function labelFor(node: GraphNode) { return localized.get(node.id)?.label ?? localized.get(node.id)?.title ?? node.label; }
   function domainFor(node: GraphNode) { return localized.get(node.id)?.domain_label ?? localizeDomain(locale, node.domain); }
   function typeFor(node: GraphNode) { return localized.get(node.id)?.type_label ?? localizeType(locale, node.type); }
   function summaryFor(node: GraphNode) { return localized.get(node.id)?.summary ?? getNodeSummary(node.id); }
-  useEffect(() => {
-    let active = true;
-    setStatusByNodeId(new Map());
-    setPersonalNotes([]);
-    if (!isSignedIn || !userId) return () => { active = false; };
 
-    void mobileApi.graph().then(({ cards, personalItems }) => {
-      if (!active) return;
-      setStatusByNodeId(new Map(cards.map((card) => [normalizeCardNodeId(card.id), card.status])));
-      setPersonalNotes(personalItems);
-    }).catch(() => {
-      if (!active) return;
+  function resetConceptSelection() {
+    setSelectedConceptId(null);
+    setSelectedPublicNode(null);
+  }
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+      setGraphOwnerId(null);
       setStatusByNodeId(new Map());
       setPersonalNotes([]);
-    });
+      if (!isSignedIn || !userId) {
+        setSelectedDomain((current) => resolveBrowseDomain(current, PUBLIC_DOMAINS, []));
+        return () => { active = false; };
+      }
+      const requestUserId = userId;
 
-    return () => { active = false; };
-  }, [isSignedIn, locale, userId]);
+      void mobileApi.graph().then(({ cards, personalItems }) => {
+        if (!active) return;
+        setStatusByNodeId(new Map(cards.map((card) => [normalizeCardNodeId(card.id), card.status])));
+        setPersonalNotes(personalItems);
+        setGraphOwnerId(requestUserId);
+        setSelectedDomain((current) => resolveBrowseDomain(current, PUBLIC_DOMAINS, personalItems));
+      }).catch(() => {
+        if (!active) return;
+        setGraphOwnerId(null);
+        setStatusByNodeId(new Map());
+        setPersonalNotes([]);
+        setSelectedDomain((current) => resolveBrowseDomain(current, PUBLIC_DOMAINS, []));
+      });
+
+      return () => { active = false; };
+    }, [isSignedIn, locale, userId]),
+  );
 
   function openActiveTopic() {
     if (!activeNode) return;
@@ -94,7 +155,7 @@ export default function BrowseScreen() {
   return (
     <SafeAreaView style={[styles.safeArea, { direction }]}>
       <FlatList
-        data={nodes}
+        data={concepts}
         keyExtractor={(item) => item.id}
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={styles.content}
@@ -102,14 +163,17 @@ export default function BrowseScreen() {
           <View>
             <Text style={styles.kicker}>{t('browse.title')}</Text>
             <Text style={styles.title}>{t('browse.findTopic')}</Text>
-                {isSignedIn && userId && personalNotes.length > 0 ? <View style={styles.personalPanel}><Text style={styles.personalTitle}>● {plural('browse.privateNotes', personalNotes.length)}</Text><Text style={styles.personalCopy}>{t('browse.privateCopy')}</Text></View> : null}
+                {isSignedIn && userId && currentPersonalNotes.length > 0 ? <View style={styles.personalPanel}><Text style={styles.personalTitle}>● {plural('browse.privateNotes', currentPersonalNotes.length)}</Text><Text style={styles.personalCopy}>{t('browse.privateCopy')}</Text></View> : null}
 
             <TextInput
               accessibilityLabel={t('browse.searchA11y')}
               autoCapitalize="none"
               autoCorrect={false}
               clearButtonMode="while-editing"
-              onChangeText={setQuery}
+              onChangeText={(nextQuery) => {
+                resetConceptSelection();
+                setQuery(nextQuery);
+              }}
               placeholder={t('browse.searchPlaceholder')}
               placeholderTextColor="#8a96a3"
               returnKeyType="search"
@@ -127,7 +191,10 @@ export default function BrowseScreen() {
                   key={domain}
                   accessibilityRole="button"
                   accessibilityState={{ selected: selectedDomain === domain }}
-                  onPress={() => setSelectedDomain(domain)}
+                  onPress={() => {
+                    resetConceptSelection();
+                    setSelectedDomain(domain);
+                  }}
                   style={({ pressed }) => [
                     styles.filterChip,
                     selectedDomain === domain && styles.filterChipSelected,
@@ -151,7 +218,10 @@ export default function BrowseScreen() {
                   key={difficulty}
                   accessibilityRole="button"
                   accessibilityState={{ selected: selectedDifficulty === difficulty }}
-                  onPress={() => setSelectedDifficulty(difficulty)}
+                  onPress={() => {
+                    resetConceptSelection();
+                    setSelectedDifficulty(difficulty);
+                  }}
                   style={({ pressed }) => [
                     styles.smallChip,
                     selectedDifficulty === difficulty && styles.filterChipSelected,
@@ -169,22 +239,53 @@ export default function BrowseScreen() {
               ))}
             </ScrollView>
 
-            {activeNode ? (
+            {activeConcept ? (
               <View style={styles.previewPanel}>
                 <View style={styles.previewHeader}>
-                  <View style={[styles.domainDot, { backgroundColor: getDomainColor(activeNode.domain) }]} />
-                  <Text style={styles.previewDomain}>{domainFor(activeNode)}</Text>
+                  <View
+                    style={[
+                      styles.domainDot,
+                      { backgroundColor: activeNote ? '#a855f7' : getDomainColor(activeNode?.domain ?? 'misc') },
+                    ]}
+                  />
+                  <Text style={styles.previewDomain}>
+                    {activeNote
+                      ? activeNote.topic ? localizeDomain(locale, activeNote.topic) : t('notes.title')
+                      : activeNode
+                        ? domainFor(activeNode)
+                        : ''}
+                  </Text>
                 </View>
-                <Text style={styles.previewTitle}>{labelFor(activeNode)}</Text>
-                <Text style={styles.previewText}>{summaryFor(activeNode)}</Text>
-                <TranslationFallbackNotice dark translation={localized.get(activeNode.id)} />
-                {relatedNodes.length > 0 ? (
+                <Text style={styles.previewTitle}>
+                  {activeNote?.title ?? (activeNode ? labelFor(activeNode) : '')}
+                </Text>
+                <Text style={styles.previewText} numberOfLines={6}>
+                  {activeNote
+                    ? activeNote.summary || activeNote.content || t('browse.privateCopy')
+                    : activeNode
+                      ? summaryFor(activeNode)
+                      : ''}
+                </Text>
+                {activeNode ? <TranslationFallbackNotice dark translation={localized.get(activeNode.id)} /> : null}
+                {activeNote?.tags.length ? (
+                  <View style={styles.relatedRow}>
+                    {activeNote.tags.map((tag) => (
+                      <View key={tag} style={styles.relatedChip}>
+                        <Text style={styles.relatedText} numberOfLines={1}>#{tag}</Text>
+                      </View>
+                    ))}
+                  </View>
+                ) : null}
+                {activeNode && relatedNodes.length > 0 ? (
                   <View style={styles.relatedRow}>
                     {relatedNodes.map((node) => (
                       <Pressable
                         key={node.id}
                         accessibilityRole="button"
-                        onPress={() => setSelectedNode(node)}
+                        onPress={() => {
+                          setSelectedConceptId(node.id);
+                          setSelectedPublicNode(node);
+                        }}
                         style={({ pressed }) => [styles.relatedChip, pressed && styles.pressed]}
                       >
                         <Text style={styles.relatedText} numberOfLines={1}>
@@ -194,20 +295,22 @@ export default function BrowseScreen() {
                     ))}
                   </View>
                 ) : null}
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={t('home.openTopicA11y', { topic: labelFor(activeNode) })}
-                  onPress={openActiveTopic}
-                  style={({ pressed }) => [styles.openButton, pressed && styles.pressed]}
-                >
-                  <Text style={styles.openButtonText}>{t('home.openTopic')}</Text>
-                </Pressable>
+                {activeNode ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={t('home.openTopicA11y', { topic: labelFor(activeNode) })}
+                    onPress={openActiveTopic}
+                    style={({ pressed }) => [styles.openButton, pressed && styles.pressed]}
+                  >
+                    <Text style={styles.openButtonText}>{t('home.openTopic')}</Text>
+                  </Pressable>
+                ) : null}
               </View>
             ) : null}
 
             <View style={styles.resultHeader}>
               <Text style={styles.resultTitle}>{t('browse.results')}</Text>
-              <Text style={styles.resultCount}>{formatNumber(nodes.length)}</Text>
+              <Text style={styles.resultCount}>{formatNumber(concepts.length)}</Text>
             </View>
           </View>
         }
@@ -220,25 +323,39 @@ export default function BrowseScreen() {
         renderItem={({ item }) => (
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel={t('browse.previewTopic', { topic: labelFor(item) })}
-            onPress={() => setSelectedNode(item)}
+            accessibilityLabel={t('browse.previewTopic', {
+              topic: item.kind === 'personal' ? item.note.title : labelFor(item.node),
+            })}
+            onPress={() => {
+              setSelectedConceptId(item.id);
+              setSelectedPublicNode(item.kind === 'public' ? item.node : null);
+            }}
             style={({ pressed }) => [
               styles.nodeRow,
-              activeNode?.id === item.id && styles.nodeRowSelected,
+              activeConcept?.id === item.id && styles.nodeRowSelected,
               pressed && styles.pressed,
             ]}
           >
-            <View style={[styles.nodeAccent, { backgroundColor: getDomainColor(item.domain) }]} />
+            <View
+              style={[
+                styles.nodeAccent,
+                { backgroundColor: item.kind === 'personal' ? '#a855f7' : getDomainColor(item.node.domain) },
+              ]}
+            />
             <View style={styles.nodeTextBlock}>
               <Text style={styles.nodeTitle} numberOfLines={1}>
-                {labelFor(item)}
+                {item.kind === 'personal' ? item.note.title : labelFor(item.node)}
               </Text>
               <Text style={styles.nodeMeta} numberOfLines={1}>
-                {domainFor(item)} / {typeFor(item)}{statusByNodeId.get(item.id) === 'known' ? ` / ${t('browse.explainable')}` : statusByNodeId.get(item.id) === 'saved' ? ` / ${t('browse.unclear')}` : ''}
+                {item.kind === 'personal'
+                  ? `${item.note.topic ? localizeDomain(locale, item.note.topic) : t('notes.title')} / ${t('notes.private')}`
+                  : `${domainFor(item.node)} / ${typeFor(item.node)}${currentStatusByNodeId.get(item.node.id) === 'known' ? ` / ${t('browse.explainable')}` : currentStatusByNodeId.get(item.node.id) === 'saved' ? ` / ${t('browse.unclear')}` : ''}`}
               </Text>
             </View>
             <Text style={styles.nodeLevel}>
-              {t('home.difficulty', { value: formatNumber(item.difficulty) })}
+              {item.kind === 'personal'
+                ? t('notes.title')
+                : t('home.difficulty', { value: formatNumber(item.node.difficulty) })}
             </Text>
           </Pressable>
         )}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { type Href, useRouter } from 'expo-router';
+import { useCallback, useMemo, useState } from 'react';
+import { type Href, useFocusEffect, useRouter } from 'expo-router';
 import {
   FlatList,
   Pressable,
@@ -26,14 +26,17 @@ import {
   getNodeSummary,
   getPrerequisiteCount,
 } from '@/knowledge';
-import { mobileApi, type PersonalNoteSummary } from '@/api';
-import type { MobileCard } from '@/api';
+import { mobileApi, type GraphCardSummary, type PersonalNoteSummary } from '@/api';
+import { isCurrentPrivateGraphOwner } from '@/browse-concepts';
 import { useMobileAuth } from '@/auth';
 import { LanguageSelector } from '@/components/language-selector';
 import { TranslationFallbackNotice } from '@/components/translation-fallback-notice';
 import { useI18n } from '@/i18n';
 import { normalizeCardNodeId, useLocalizedContent } from '@/localized-content';
 import { localizeDomain, localizeType } from '@stem-brain/shared';
+
+const EMPTY_PERSONAL_NOTES: PersonalNoteSummary[] = [];
+const EMPTY_CARDS_BY_NODE_ID = new Map<string, GraphCardSummary>();
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -51,34 +54,44 @@ export default function HomeScreen() {
   const visibleNodes = useMemo(() => filterNodes({ domain: selectedDomain, limit: 36 }), [selectedDomain]);
   const prerequisiteCount = useMemo(() => getPrerequisiteCount(selectedNode.id), [selectedNode.id]);
   const [personalNotes, setPersonalNotes] = useState<PersonalNoteSummary[]>([]);
-  const [cardsByNodeId, setCardsByNodeId] = useState<Map<string, MobileCard>>(new Map());
+  const [cardsByNodeId, setCardsByNodeId] = useState<Map<string, GraphCardSummary>>(new Map());
+  const [graphOwnerId, setGraphOwnerId] = useState<string | null>(null);
+  const hasCurrentPrivateGraph = isCurrentPrivateGraphOwner(isSignedIn, userId, graphOwnerId);
+  const currentPersonalNotes = hasCurrentPrivateGraph ? personalNotes : EMPTY_PERSONAL_NOTES;
+  const currentCardsByNodeId = hasCurrentPrivateGraph ? cardsByNodeId : EMPTY_CARDS_BY_NODE_ID;
   const contentIds = useMemo(() => [...new Set([...visibleNodes.map((node) => node.id), ...featuredNodes.map((node) => node.id), selectedNode.id])], [featuredNodes, selectedNode.id, visibleNodes]);
   const localized = useLocalizedContent(contentIds, selectedNode.id);
 
-  function cardFor(node: GraphNode) { return cardsByNodeId.get(node.id); }
+  function cardFor(node: GraphNode) { return currentCardsByNodeId.get(node.id); }
   function labelFor(node: GraphNode) { return cardFor(node)?.title ?? localized.get(node.id)?.label ?? localized.get(node.id)?.title ?? node.label; }
-  function domainFor(node: GraphNode) { return cardFor(node)?.domain_label ?? localized.get(node.id)?.domain_label ?? localizeDomain(locale, node.domain); }
-  function typeFor(node: GraphNode) { return cardFor(node)?.type_label ?? localized.get(node.id)?.type_label ?? localizeType(locale, node.type); }
-  function summaryFor(node: GraphNode) { return cardFor(node)?.summary ?? localized.get(node.id)?.summary ?? getNodeSummary(node.id); }
+  function domainFor(node: GraphNode) { return localized.get(node.id)?.domain_label ?? localizeDomain(locale, node.domain); }
+  function typeFor(node: GraphNode) { return localized.get(node.id)?.type_label ?? localizeType(locale, node.type); }
+  function summaryFor(node: GraphNode) { return localized.get(node.id)?.summary ?? getNodeSummary(node.id); }
 
-  useEffect(() => {
-    let active = true;
-    setPersonalNotes([]);
-    setCardsByNodeId(new Map());
-    if (!isSignedIn || !userId) return () => { active = false; };
-
-    void mobileApi.graph().then(({ cards, personalItems }) => {
-      if (!active) return;
-      setPersonalNotes(personalItems);
-      setCardsByNodeId(new Map(cards.map((card) => [normalizeCardNodeId(card.id), card])));
-    }).catch(() => {
-      if (!active) return;
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+      setGraphOwnerId(null);
       setPersonalNotes([]);
       setCardsByNodeId(new Map());
-    });
+      if (!isSignedIn || !userId) return () => { active = false; };
+      const requestUserId = userId;
 
-    return () => { active = false; };
-  }, [isSignedIn, locale, userId]);
+      void mobileApi.graph().then(({ cards, personalItems }) => {
+        if (!active) return;
+        setPersonalNotes(personalItems);
+        setCardsByNodeId(new Map(cards.map((card) => [normalizeCardNodeId(card.id), card])));
+        setGraphOwnerId(requestUserId);
+      }).catch(() => {
+        if (!active) return;
+        setGraphOwnerId(null);
+        setPersonalNotes([]);
+        setCardsByNodeId(new Map());
+      });
+
+      return () => { active = false; };
+    }, [isSignedIn, locale, userId]),
+  );
 
   function openSelectedTopic() {
     router.push({ pathname: '/topic/[id]', params: { id: selectedNode.id } });
@@ -158,7 +171,7 @@ export default function HomeScreen() {
               </View>
               <Text style={styles.detailTitle}>{labelFor(selectedNode)}</Text>
               <Text style={styles.detailText}>{summaryFor(selectedNode)}</Text>
-              <TranslationFallbackNotice dark translation={cardFor(selectedNode) ?? localized.get(selectedNode.id)} />
+              <TranslationFallbackNotice dark translation={localized.get(selectedNode.id)} />
               <View style={styles.metaRow}>
                 <Text style={styles.metaChip}>{typeFor(selectedNode)}</Text>
                 <Text style={styles.metaChip}>{t('home.level', { value: formatNumber(selectedNode.level) })}</Text>
@@ -174,7 +187,7 @@ export default function HomeScreen() {
               </Pressable>
             </View>
 
-            {isSignedIn && userId && personalNotes.length > 0 ? (
+            {isSignedIn && userId && currentPersonalNotes.length > 0 ? (
               <View style={styles.personalPanel}>
                 <View style={styles.personalHeader}>
                   <Text style={styles.personalTitle}>{t('home.myNotesPrivate')}</Text>
@@ -183,7 +196,7 @@ export default function HomeScreen() {
                   </Pressable>
                 </View>
                 <Text style={styles.personalCopy}>{t('home.privateNotesCopy')}</Text>
-                {personalNotes.slice(0, 3).map((note) => <Text key={note.id} style={styles.personalNote} numberOfLines={1}>● {note.title}</Text>)}
+                {currentPersonalNotes.slice(0, 3).map((note) => <Text key={note.id} style={styles.personalNote} numberOfLines={1}>● {note.title}</Text>)}
               </View>
             ) : null}
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,7 @@
     "build": "pnpm run build:ios && pnpm run build:android",
     "build:ios": "expo export --platform ios --output-dir dist/ios --no-bytecode",
     "build:android": "expo export --platform android --output-dir dist/android --no-bytecode",
-    "test": "tsx --test src/subscription-purchase-guard.test.ts",
+    "test": "tsx --test src/subscription-purchase-guard.test.ts src/browse-concepts.test.ts",
     "eas:login": "pnpm --workspace-root exec eas login",
     "eas:init": "pnpm --workspace-root exec eas init",
     "eas:android:development": "pnpm --workspace-root exec eas build --platform android --profile development",

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -57,15 +57,18 @@ export type ContentResponse = {
 export type PersonalNote = {
   id: string;
   title: string;
+  summary: string;
   content: string;
   topic: string;
+  tags: string[];
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
   purge_at: string | null;
 };
 
-export type PersonalNoteSummary = Pick<PersonalNote, 'id' | 'title' | 'topic'>;
+export type PersonalNoteSummary = Pick<PersonalNote, 'id' | 'title' | 'summary' | 'content' | 'topic' | 'tags' | 'created_at' | 'updated_at'>;
+export type GraphCardSummary = Pick<MobileCard, 'id' | 'title' | 'status'>;
 
 function getBaseUrl() {
   if (!apiBaseUrl) throw new Error(translate(getActiveLocale(), 'api.missingUrl'));
@@ -134,7 +137,7 @@ export const mobileApi = {
     return publicRequest<ContentResponse>(withLocale(`/api/mobile?resource=content&ids=${query}`));
   },
   notes: (view: 'active' | 'trash' = 'active') => request<{ items: PersonalNote[] }>(withLocale(`/api/mobile?resource=notes&view=${view}`)),
-  graph: () => request<{ cards: MobileCard[]; personalItems: PersonalNoteSummary[] }>(withLocale('/api/mobile?resource=graph')),
+  graph: () => request<{ cards: GraphCardSummary[]; personalItems: PersonalNoteSummary[] }>(withLocale('/api/mobile?resource=graph')),
   practice: (mode: 'new' | 'review', exclude: string[] = []) => request<{ card: MobileCard | null; stats: { explainable: number; unclear: number } }>(withLocale(`/api/mobile?resource=practice&mode=${mode}${exclude.map((id) => `&exclude=${encodeURIComponent(id)}`).join('')}`)),
   saved: () => request<{ cards: MobileCard[] }>(withLocale('/api/mobile?resource=saved')),
   dashboard: () => request<{ stats: { explainable: number; unclear: number }; domains: Array<{ domain: string; domain_label?: string; reviewed: number; explainable: number; unclear: number }> }>(withLocale('/api/mobile?resource=dashboard')),

--- a/apps/mobile/src/browse-concepts.test.ts
+++ b/apps/mobile/src/browse-concepts.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GraphNode } from '@stem-brain/graph-engine';
+import {
+  filterPersonalBrowseConcepts,
+  isCurrentPrivateGraphOwner,
+  mergeBrowseConcepts,
+  mergeBrowseDomains,
+  resolveBrowseDomain,
+} from './browse-concepts';
+
+const publicNode: GraphNode = {
+  id: 'gradient_descent',
+  label: 'Gradient Descent',
+  domain: 'Machine Learning',
+  level: 2,
+  difficulty: 3,
+  type: 'algorithm',
+};
+
+const privateNote = {
+  id: 'note-1',
+  title: 'Learning-rate checklist',
+  summary: 'A short optimization reminder',
+  content: 'Reduce the step size when training diverges.',
+  topic: 'machine-learning',
+  tags: ['optimization'],
+};
+
+test('injects private notes into Concepts with collision-safe personal ids', () => {
+  const concepts = mergeBrowseConcepts([{ ...publicNode, id: privateNote.id }], [privateNote]);
+
+  assert.deepEqual(concepts.map((concept) => concept.id), ['personal:note-1', 'note-1']);
+  assert.equal(concepts[0]?.kind, 'personal');
+  assert.equal(concepts[1]?.kind, 'public');
+});
+
+test('shows private graph state only for the currently authenticated owner', () => {
+  assert.equal(isCurrentPrivateGraphOwner(true, 'user-a', 'user-a'), true);
+  assert.equal(isCurrentPrivateGraphOwner(true, 'user-b', 'user-a'), false);
+  assert.equal(isCurrentPrivateGraphOwner(false, 'user-a', 'user-a'), false);
+  assert.equal(isCurrentPrivateGraphOwner(true, null, 'user-a'), false);
+});
+
+test('normalizes personal topics and resolves removed topic filters', () => {
+  assert.deepEqual(
+    mergeBrowseDomains(['All', 'Machine Learning'], [privateNote]),
+    ['All', 'Machine Learning'],
+  );
+  assert.deepEqual(
+    mergeBrowseDomains(['All', 'Machine Learning'], [{ ...privateNote, topic: 'all' }]),
+    ['All', 'Machine Learning'],
+  );
+  assert.equal(
+    resolveBrowseDomain('machine-learning', ['All', 'Machine Learning'], [privateNote]),
+    'Machine Learning',
+  );
+  assert.equal(
+    resolveBrowseDomain('custom-topic', ['All', 'Machine Learning'], [
+      { ...privateNote, topic: 'custom-topic' },
+    ]),
+    'custom-topic',
+  );
+  assert.equal(
+    resolveBrowseDomain('custom-topic', ['All', 'Machine Learning'], []),
+    'All',
+  );
+});
+
+test('searches private concept content and respects concept filters', () => {
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: 'step size',
+      domain: 'All',
+      difficulty: 'All',
+      locale: 'en',
+    }),
+    [privateNote],
+  );
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: 'optimization',
+      domain: 'Machine Learning',
+      difficulty: 'All',
+      locale: 'en',
+    }),
+    [privateNote],
+  );
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: 'machine learning',
+      domain: 'All',
+      difficulty: 'All',
+      locale: 'en',
+    }),
+    [privateNote],
+  );
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: '#optimization',
+      domain: 'All',
+      difficulty: 'All',
+      locale: 'en',
+    }),
+    [privateNote],
+  );
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: '',
+      domain: 'Mathematics',
+      difficulty: 'All',
+      locale: 'en',
+    }),
+    [],
+  );
+  assert.deepEqual(
+    filterPersonalBrowseConcepts([privateNote], {
+      query: '',
+      domain: 'All',
+      difficulty: 3,
+      locale: 'en',
+    }),
+    [],
+  );
+});

--- a/apps/mobile/src/browse-concepts.ts
+++ b/apps/mobile/src/browse-concepts.ts
@@ -1,0 +1,112 @@
+import type { GraphNode } from '@stem-brain/graph-engine';
+
+export type PersonalBrowseConcept = {
+  id: string;
+  title: string;
+  summary: string;
+  content: string;
+  topic: string;
+  tags: string[];
+};
+
+export type BrowseConcept =
+  | { kind: 'public'; id: string; node: GraphNode }
+  | { kind: 'personal'; id: `personal:${string}`; note: PersonalBrowseConcept };
+
+type PersonalConceptFilter = {
+  query: string;
+  domain: string;
+  difficulty: 'All' | number;
+  locale: string;
+};
+
+function normalizeBrowseSearch(value: string, locale: string) {
+  return value
+    .normalize('NFKC')
+    .trim()
+    .toLocaleLowerCase(locale)
+    .replace(/^#+/u, '')
+    .replace(/[\s/_-]+/gu, ' ');
+}
+
+export function isCurrentPrivateGraphOwner(
+  isSignedIn: boolean | undefined,
+  currentUserId: string | null | undefined,
+  graphOwnerId: string | null,
+) {
+  return Boolean(isSignedIn && currentUserId && graphOwnerId === currentUserId);
+}
+
+export function canonicalizeBrowseDomain(value: string) {
+  return value
+    .normalize('NFKC')
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[\s/_-]+/gu, '-')
+    .replace(/[^\p{L}\p{N}-]+/gu, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function mergeBrowseDomains(
+  publicDomains: readonly string[],
+  personalNotes: readonly PersonalBrowseConcept[],
+) {
+  const domains = new Map<string, string>();
+  const candidates = [
+    ...publicDomains.filter((domain) => domain !== 'All'),
+    ...personalNotes.map((note) => note.topic),
+  ];
+
+  for (const candidate of candidates) {
+    const value = candidate.trim();
+    const key = canonicalizeBrowseDomain(value);
+    if (key && key !== 'all' && !domains.has(key)) domains.set(key, value);
+  }
+
+  return ['All', ...domains.values()];
+}
+
+export function resolveBrowseDomain(
+  selectedDomain: string,
+  publicDomains: readonly string[],
+  personalNotes: readonly PersonalBrowseConcept[],
+) {
+  const selectedKey = canonicalizeBrowseDomain(selectedDomain);
+  return mergeBrowseDomains(publicDomains, personalNotes)
+    .find((domain) => canonicalizeBrowseDomain(domain) === selectedKey) ?? 'All';
+}
+
+export function filterPersonalBrowseConcepts<T extends PersonalBrowseConcept>(
+  notes: readonly T[],
+  { query, domain, difficulty, locale }: PersonalConceptFilter,
+): T[] {
+  if (difficulty !== 'All') return [];
+
+  const normalizedQuery = normalizeBrowseSearch(query, locale);
+  const normalizedDomain = canonicalizeBrowseDomain(domain);
+
+  return notes.filter((note) => {
+    const matchesDomain = domain === 'All' || canonicalizeBrowseDomain(note.topic) === normalizedDomain;
+    if (!matchesDomain) return false;
+    if (!normalizedQuery) return true;
+
+    return [note.title, note.summary, note.content, note.topic, ...(note.tags ?? [])]
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      .some((value) => normalizeBrowseSearch(value, locale).includes(normalizedQuery));
+  });
+}
+
+export function mergeBrowseConcepts(
+  publicNodes: readonly GraphNode[],
+  personalNotes: readonly PersonalBrowseConcept[],
+): BrowseConcept[] {
+  return [
+    ...personalNotes.map((note) => ({
+      kind: 'personal' as const,
+      id: `personal:${note.id}` as const,
+      note,
+    })),
+    ...publicNodes.map((node) => ({ kind: 'public' as const, id: node.id, node })),
+  ];
+}

--- a/apps/web/e2e/stabilization.spec.ts
+++ b/apps/web/e2e/stabilization.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+const usesDeployedPreview = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+
 test.describe('main stabilization regressions', () => {
   test('clearing filters in My Notes trash keeps the trash view', async ({ page }) => {
     await page.goto('/my-knowledge?view=trash&q=no-match');
@@ -9,6 +11,31 @@ test.describe('main stabilization regressions', () => {
       'href',
       /\/(?:en\/)?my-knowledge\?view=trash$/
     );
+  });
+
+  test('a guest note appears as one private Concepts card', async ({ page }, testInfo) => {
+    test.skip(
+      usesDeployedPreview,
+      'Guest-note mutations are covered by the isolated local in-memory browser suite.',
+    );
+
+    const title = `Guest concept injection ${testInfo.project.name} ${Date.now()}`;
+
+    await page.goto('/my-knowledge');
+    await page.locator('#new-title').fill(title);
+    await page.locator('#new-topic').fill('machine-learning');
+    await page.locator('#new-summary').fill('A private note rendered in Concepts.');
+    await page.locator('#new-tags').fill('optimization');
+    await page.getByRole('button', { name: 'Save item' }).click();
+
+    await expect(page.getByRole('heading', { name: title, level: 3 })).toBeVisible();
+
+    await page.goto('/grid');
+    const privateCard = page.getByTestId('concept-card').filter({ hasText: title });
+    await expect(privateCard).toHaveCount(1);
+    await expect(privateCard).toContainText('Private card');
+    await expect(privateCard).toContainText('Machine Learning');
+    await expect(privateCard).toContainText('#optimization');
   });
 
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,3 +15,9 @@ const nextConfig: NextConfig = {
 };
 
 export default nextConfig;
+
+void initOpenNextCloudflareForDev({
+  configPath: path.join(appDir, 'wrangler.dev.jsonc'),
+  persist: false,
+  remoteBindings: false,
+});

--- a/apps/web/src/actions/knowledge-ingestion-actions.ts
+++ b/apps/web/src/actions/knowledge-ingestion-actions.ts
@@ -39,6 +39,7 @@ function revalidateKnowledgeSurfaces(batchId?: string) {
   revalidatePath('/knowledge-inbox');
   if (batchId) revalidatePath(`/knowledge-inbox/${batchId}`);
   revalidatePath('/my-knowledge');
+  revalidatePath('/grid');
   revalidatePath('/knowledge');
 }
 

--- a/apps/web/src/actions/user-knowledge-actions.ts
+++ b/apps/web/src/actions/user-knowledge-actions.ts
@@ -161,6 +161,8 @@ export async function createKnowledgeItem(formData: FormData): Promise<void> {
     }
 
     revalidatePath('/my-knowledge');
+    revalidatePath('/grid');
+    revalidatePath('/knowledge');
     return;
   }
 
@@ -200,6 +202,8 @@ export async function createKnowledgeItem(formData: FormData): Promise<void> {
   }
 
   revalidatePath('/my-knowledge');
+  revalidatePath('/grid');
+  revalidatePath('/knowledge');
 }
 
 export async function updateKnowledgeItem(formData: FormData): Promise<void> {
@@ -222,6 +226,8 @@ export async function updateKnowledgeItem(formData: FormData): Promise<void> {
     updateMemoryKnowledgeItemForUser(user.id, id, { title, summary, content, topic, tags }, { syncGraph });
 
     revalidatePath('/my-knowledge');
+    revalidatePath('/grid');
+    revalidatePath('/knowledge');
     return;
   }
 
@@ -240,6 +246,8 @@ export async function updateKnowledgeItem(formData: FormData): Promise<void> {
   );
 
   revalidatePath('/my-knowledge');
+  revalidatePath('/grid');
+  revalidatePath('/knowledge');
 }
 
 export async function deleteKnowledgeItem(formData: FormData): Promise<void> {
@@ -255,6 +263,7 @@ export async function deleteKnowledgeItem(formData: FormData): Promise<void> {
     softDeleteMemoryKnowledgeItemForUser(user.id, id, PERSONAL_CARD_RETENTION_DAYS, { syncGraph });
 
     revalidatePath('/my-knowledge');
+    revalidatePath('/grid');
     revalidatePath('/knowledge');
     return;
   }
@@ -279,6 +288,7 @@ export async function deleteKnowledgeItem(formData: FormData): Promise<void> {
   );
 
   revalidatePath('/my-knowledge');
+  revalidatePath('/grid');
   revalidatePath('/knowledge');
 }
 
@@ -334,5 +344,6 @@ export async function restoreKnowledgeItem(formData: FormData): Promise<void> {
   }
 
   revalidatePath('/my-knowledge');
+  revalidatePath('/grid');
   revalidatePath('/knowledge');
 }

--- a/apps/web/src/app/api/mobile/route.ts
+++ b/apps/web/src/app/api/mobile/route.ts
@@ -19,6 +19,7 @@ import {
   getUserKnowledgeItems,
   restoreKnowledgeItem,
   updateKnowledgeItem,
+  type UserKnowledgeItem,
 } from '@/actions/user-knowledge-actions';
 import {
   createAdminEdge,
@@ -53,6 +54,40 @@ function unauthorized() {
 
 function invalid(message: string, code = 'INVALID_REQUEST') {
   return NextResponse.json({ error: message, code }, { status: 400 });
+}
+
+function privateJson(body: unknown) {
+  return NextResponse.json(body, {
+    headers: { 'Cache-Control': 'private, no-store' },
+  });
+}
+
+function toMobileNote(item: UserKnowledgeItem) {
+  return {
+    id: item.id,
+    title: item.title,
+    summary: item.summary,
+    content: item.content,
+    topic: item.topic,
+    tags: item.tags,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    deleted_at: item.deleted_at,
+    purge_at: item.purge_at,
+  };
+}
+
+function toMobileConcept(item: UserKnowledgeItem) {
+  return {
+    id: item.id,
+    title: item.title,
+    summary: item.summary,
+    content: item.content,
+    topic: item.topic,
+    tags: item.tags,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+  };
 }
 
 function stringField(value: unknown, maxLength: number) {
@@ -110,16 +145,16 @@ export async function GET(request: NextRequest) {
     case 'notes': {
       const view = request.nextUrl.searchParams.get('view');
       const items = view === 'trash' ? await getDeletedKnowledgeItems() : await getUserKnowledgeItems();
-      return NextResponse.json({ items });
+      return privateJson({ items: items.map(toMobileNote) });
     }
     case 'graph': {
       const [cards, personalItems] = await Promise.all([
         getAllCardsWithStatus({ locale }),
         getUserKnowledgeItems(),
       ]);
-      return NextResponse.json({
+      return privateJson({
         cards: cards.map((card) => ({ id: card.id, title: card.title, status: card.status })),
-        personalItems: personalItems.map((item) => ({ id: item.id, title: item.title, topic: item.topic })),
+        personalItems: personalItems.map(toMobileConcept),
       });
     }
     case 'practice': {

--- a/apps/web/src/app/grid/page.tsx
+++ b/apps/web/src/app/grid/page.tsx
@@ -12,11 +12,14 @@ export default async function GridPage() {
   const [actor, locale] = await Promise.all([getCurrentActor(), getServerLocale()]);
   const [cards, personalItems, publicEdges, privateGraph, graphLinkTargets] = await Promise.all([
     getAllCardsWithStatus({ locale }),
-    actor.isGuest ? Promise.resolve([]) : getUserKnowledgeItems(),
+    getUserKnowledgeItems(),
     getKnowledgeMapEdges(),
     actor.isGuest ? Promise.resolve(null) : getPrivateKnowledgeGraph(),
     actor.isGuest ? Promise.resolve([]) : getKnowledgeLinkTargets(),
   ]);
+  const personalMapItems = personalItems.map(({
+    id, title, summary, content, topic, tags, created_at, updated_at,
+  }) => ({ id, title, summary, content, topic, tags, created_at, updated_at }));
 
   return (
     <main className="min-h-screen bg-gray-50 flex flex-col">
@@ -25,7 +28,7 @@ export default async function GridPage() {
         <KnowledgeMap
           initialCards={cards}
           initialView="grid"
-          personalItems={actor.isGuest ? [] : personalItems}
+          personalItems={personalMapItems}
           publicEdges={publicEdges}
           privateGraph={actor.isGuest ? null : privateGraph}
           graphLinkTargets={graphLinkTargets}

--- a/apps/web/src/app/knowledge/page.tsx
+++ b/apps/web/src/app/knowledge/page.tsx
@@ -14,11 +14,14 @@ export default async function KnowledgePage() {
   const [actor, locale] = await Promise.all([getCurrentActor(), getServerLocale()]);
   const [cards, personalItems, publicEdges, privateGraph, graphLinkTargets] = await Promise.all([
     getAllCardsWithStatus({ locale }),
-    actor.isGuest ? Promise.resolve([]) : getUserKnowledgeItems(),
+    getUserKnowledgeItems(),
     getKnowledgeMapEdges(),
     actor.isGuest ? Promise.resolve(null) : getPrivateKnowledgeGraph(),
     actor.isGuest ? Promise.resolve([]) : getKnowledgeLinkTargets(),
   ]);
+  const personalMapItems = personalItems.map(({
+    id, title, summary, content, topic, tags, created_at, updated_at,
+  }) => ({ id, title, summary, content, topic, tags, created_at, updated_at }));
 
   return (
     <main className="min-h-screen bg-gray-50 flex flex-col">
@@ -27,7 +30,7 @@ export default async function KnowledgePage() {
         <div className="mx-auto flex h-full w-full max-w-6xl">
           <KnowledgeMap
           initialCards={cards}
-          personalItems={actor.isGuest ? [] : personalItems}
+          personalItems={personalMapItems}
           publicEdges={publicEdges}
           privateGraph={actor.isGuest ? null : privateGraph}
           graphLinkTargets={graphLinkTargets}

--- a/apps/web/src/components/knowledge-map.tsx
+++ b/apps/web/src/components/knowledge-map.tsx
@@ -30,10 +30,15 @@ type MapCard = KnowledgeCard & {
   tags?: string[];
 };
 
+type KnowledgeMapPersonalItem = Pick<
+  UserKnowledgeItem,
+  'id' | 'title' | 'summary' | 'content' | 'topic' | 'tags' | 'created_at' | 'updated_at'
+>;
+
 type Props = {
   initialCards: (KnowledgeCard & { status: CardStatus | null })[];
   initialView?: 'grid' | 'graph';
-  personalItems?: UserKnowledgeItem[];
+  personalItems?: KnowledgeMapPersonalItem[];
   publicEdges?: KnowledgeMapEdge[];
   privateGraph?: {
     nodes?: unknown[];

--- a/apps/web/src/lib/stabilization.test.ts
+++ b/apps/web/src/lib/stabilization.test.ts
@@ -211,11 +211,36 @@ test('mobile private graph summaries are invalidated on account transitions', as
   ]);
 
   for (const source of [homeSource, browseSource]) {
+    assert.match(source, /useFocusEffect\(/);
     assert.match(source, /let active = true;/);
     assert.match(source, /if \(!isSignedIn \|\| !userId\)/);
     assert.match(source, /if \(!active\)|if \(active\)/);
     assert.match(source, /return \(\) => \{ active = false; \};/);
     assert.match(source, /\[isSignedIn, (?:locale, )?userId\]/);
-    assert.match(source, /isSignedIn && userId && personalNotes\.length > 0/);
+    assert.match(source, /isCurrentPrivateGraphOwner\(isSignedIn, userId, graphOwnerId\)/);
+    assert.match(source, /setGraphOwnerId\(requestUserId\)/);
+    assert.match(source, /isSignedIn && userId && currentPersonalNotes\.length > 0/);
+  }
+  assert.match(browseSource, /mergeBrowseConcepts\(publicNodes, visiblePersonalNotes\)/);
+  assert.match(browseSource, /data=\{concepts\}/);
+});
+
+test('web Concepts includes current guest notes without enabling the signed-in private graph', async () => {
+  const sources = await Promise.all([
+    readFile(new URL('../app/grid/page.tsx', import.meta.url), 'utf8'),
+    readFile(new URL('../app/knowledge/page.tsx', import.meta.url), 'utf8'),
+  ]);
+
+  for (const source of sources) {
+    assert.match(source, /getUserKnowledgeItems\(\),/);
+    assert.doesNotMatch(
+      source,
+      /actor\.isGuest \? Promise\.resolve\(\[\]\) : getUserKnowledgeItems\(\)/,
+    );
+    assert.match(source, /const personalMapItems = personalItems\.map/);
+    assert.match(source, /personalItems=\{personalMapItems\}/);
+    assert.doesNotMatch(source, /personalItems=\{personalItems\}/);
+    assert.doesNotMatch(source, /user_id|source_provider|source_batch_id/);
+    assert.match(source, /actor\.isGuest \? Promise\.resolve\(null\) : getPrivateKnowledgeGraph\(\)/);
   }
 });

--- a/apps/web/src/lib/static-card-content.ts
+++ b/apps/web/src/lib/static-card-content.ts
@@ -11,9 +11,7 @@ export async function getStaticCardContent(): Promise<StaticCardContent> {
     staticCardContentPromise = (async () => {
       const assets = getCloudflareContext().env.ASSETS;
       if (!assets) throw new Error('The static asset binding is unavailable.');
-      const response = await assets.fetch(
-        new Request('https://assets.local/localization/card-content.json'),
-      );
+      const response = await assets.fetch('https://assets.local/localization/card-content.json');
       if (!response.ok) {
         throw new Error(`Unable to load the static card-content asset (${response.status}).`);
       }

--- a/apps/web/wrangler.dev.jsonc
+++ b/apps/web/wrangler.dev.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "girapphe-dev-bindings",
+  "main": ".open-next/worker.js",
+  "compatibility_date": "2026-08-16",
+  "compatibility_flags": [
+    "nodejs_compat",
+    "global_fetch_strictly_public"
+  ],
+  "vars": {
+    "APP_ENV": "base"
+  },
+  "assets": {
+    "directory": "public",
+    "binding": "ASSETS"
+  }
+}

--- a/packages/graph-engine/src/domain-label.ts
+++ b/packages/graph-engine/src/domain-label.ts
@@ -5,9 +5,9 @@ export function formatDomainLabel(domain: string): string {
   if (normalized === 'artificial_intelligence') return 'AI';
   if (normalized === 'machine_learning') return 'ML';
   if (normalized === 'probability_and_statistics') return 'Probability & Statistics';
-  if (normalized.includes('_')) {
+  if (/[_-]/.test(normalized)) {
     return normalized
-      .split('_')
+      .split(/[_-]+/)
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join(' ');
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,10 @@ export default defineConfig({
     : {
         command: 'pnpm --filter @stem-brain/web dev',
         url: baseURL,
-        reuseExistingServer: !process.env.CI,
+        env: {
+          DATABASE_URL: '',
+        },
+        reuseExistingServer: false,
         timeout: 120_000,
       },
   projects: [


### PR DESCRIPTION
## Summary
- show active Notes as owner-scoped private cards in web and mobile Concepts
- refresh mobile private notes on focus and prevent cross-account state exposure
- keep private API payloads uncached and add isolated browser coverage

## Validation
- `pnpm harness:deploy`
- local desktop and mobile browser regression: guest note -> Concepts private card