### PR TITLE
fix(web): keep active mobile navigation visible

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -255,8 +255,13 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
-  test('concepts has its own navigation tab and can open the graph view', async ({ page }) => {
+  test('concepts has its own navigation tab and can open the graph view', async ({ page }, testInfo) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+    const exercisesViewportResize = testInfo.project.name === 'chromium-mobile';
+
+    if (exercisesViewportResize) {
+      await page.setViewportSize({ width: 1440, height: 900 });
+    }
 
     await page.goto('/grid');
     const conceptsTab = page.getByRole('link', { name: 'Concepts' });
@@ -271,6 +276,14 @@ test.describe('browser smoke', () => {
         && box.x + box.width <= viewport.width,
       );
     }, { message: 'active Concepts navigation tab is fully visible' }).toBe(true);
+
+    if (exercisesViewportResize) {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect.poll(async () => {
+        const box = await conceptsTab.boundingBox();
+        return Boolean(box && box.x >= 0 && box.x + box.width <= 390);
+      }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
+    }
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
 
     const groupBy = page.getByLabel('Group by');
@@ -356,23 +369,6 @@ test.describe('browser smoke', () => {
     await reopenedEditor.getByLabel('Title').fill('Editable private copy updated');
     await reopenedEditor.getByRole('button', { name: 'Save changes' }).click();
     await expect(page.getByTestId('concept-card').filter({ hasText: 'Editable private copy updated' })).toHaveCount(1);
-    await assertNoBrowserFailures();
-  });
-
-  test('active navigation stays visible when the viewport narrows', async ({ page }) => {
-    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
-
-    await page.setViewportSize({ width: 1440, height: 900 });
-    await page.goto('/grid');
-    const conceptsTab = page.getByRole('link', { name: 'Concepts' });
-    await expect(conceptsTab).toHaveAttribute('aria-current', 'page');
-
-    await page.setViewportSize({ width: 390, height: 844 });
-    await expect.poll(async () => {
-      const box = await conceptsTab.boundingBox();
-      return Boolean(box && box.x >= 0 && box.x + box.width <= 390);
-    }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
-
     await assertNoBrowserFailures();
   });
 

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -359,6 +359,23 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
+  test('active navigation stays visible when the viewport narrows', async ({ page }) => {
+    const assertNoBrowserFailures = attachBrowserFailureGuards(page);
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/grid');
+    const conceptsTab = page.getByRole('link', { name: 'Concepts' });
+    await expect(conceptsTab).toHaveAttribute('aria-current', 'page');
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect.poll(async () => {
+      const box = await conceptsTab.boundingBox();
+      return Boolean(box && box.x >= 0 && box.x + box.width <= 390);
+    }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
+
+    await assertNoBrowserFailures();
+  });
+
   test('personal knowledge exposes date controls and a trash view', async ({ page }) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -261,6 +261,16 @@ test.describe('browser smoke', () => {
     await page.goto('/grid');
     const conceptsTab = page.getByRole('link', { name: 'Concepts' });
     await expect(conceptsTab).toHaveAttribute('aria-current', 'page');
+    await expect.poll(async () => {
+      const box = await conceptsTab.boundingBox();
+      const viewport = page.viewportSize();
+      return Boolean(
+        box
+        && viewport
+        && box.x >= 0
+        && box.x + box.width <= viewport.width,
+      );
+    }, { message: 'active Concepts navigation tab is fully visible' }).toBe(true);
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
 
     const groupBy = page.getByLabel('Group by');

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import { stripLocaleFromPathname } from '@stem-brain/shared';
 import { useI18n } from '@/i18n/client';
@@ -33,6 +34,11 @@ export default function NavLinks({
   const pathname = stripLocaleFromPathname(usePathname());
   const { t } = useI18n();
   const isHome = variant === 'home';
+  const activeLinkRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    activeLinkRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [pathname]);
 
   return (
     <nav aria-label={t('nav.main')} className="min-w-0 overflow-hidden">
@@ -43,6 +49,7 @@ export default function NavLinks({
             <li key={item.href} className="shrink-0">
               <LocalizedLink
                 href={item.href}
+                ref={active ? activeLinkRef : undefined}
                 aria-current={active ? 'page' : undefined}
                 className={`inline-flex min-h-8 items-center rounded-md px-3 py-1.5 transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'focus:ring-offset-slate-950' : 'focus:ring-offset-2 focus:ring-offset-white'} ${
                   active

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -35,14 +35,25 @@ export default function NavLinks({
   const { t } = useI18n();
   const isHome = variant === 'home';
   const activeLinkRef = useRef<HTMLAnchorElement>(null);
+  const navListRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
-    activeLinkRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    const keepActiveLinkVisible = () => {
+      activeLinkRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    };
+    keepActiveLinkVisible();
+
+    const navList = navListRef.current;
+    if (!navList || typeof ResizeObserver === 'undefined') return;
+
+    const resizeObserver = new ResizeObserver(keepActiveLinkVisible);
+    resizeObserver.observe(navList);
+    return () => resizeObserver.disconnect();
   }, [pathname]);
 
   return (
     <nav aria-label={t('nav.main')} className="min-w-0 overflow-hidden">
-      <ul className={`no-scrollbar flex w-full min-w-0 items-center gap-1 overflow-x-auto rounded-lg p-1 text-sm font-medium ${isHome ? 'bg-white/[0.06] text-slate-300' : 'bg-slate-100 text-slate-600'}`}>
+      <ul ref={navListRef} className={`no-scrollbar flex w-full min-w-0 items-center gap-1 overflow-x-auto rounded-lg p-1 text-sm font-medium ${isHome ? 'bg-white/[0.06] text-slate-300' : 'bg-slate-100 text-slate-600'}`}>
         {NAV_ITEMS.filter((item) => item.href !== '/knowledge-inbox' || isAuthenticated).map((item) => {
           const active = isActive(pathname, item.href);
           return (

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -38,17 +38,30 @@ export default function NavLinks({
   const navListRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
+    let animationFrame = 0;
     const keepActiveLinkVisible = () => {
       activeLinkRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     };
-    keepActiveLinkVisible();
+    const scheduleActiveLinkAlignment = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(keepActiveLinkVisible);
+    };
+    scheduleActiveLinkAlignment();
+
+    window.addEventListener('resize', scheduleActiveLinkAlignment, { passive: true });
 
     const navList = navListRef.current;
-    if (!navList || typeof ResizeObserver === 'undefined') return;
+    let resizeObserver: ResizeObserver | null = null;
+    if (navList && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(scheduleActiveLinkAlignment);
+      resizeObserver.observe(navList);
+    }
 
-    const resizeObserver = new ResizeObserver(keepActiveLinkVisible);
-    resizeObserver.observe(navList);
-    return () => resizeObserver.disconnect();
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.removeEventListener('resize', scheduleActiveLinkAlignment);
+      resizeObserver?.disconnect();
+    };
   }, [pathname]);
 
   return (


### PR DESCRIPTION
## Summary
- scroll the active primary navigation link into the visible horizontal menu area after route changes
- add a rendered regression assertion that the active Concepts tab stays fully inside the viewport on desktop and mobile

## UX evidence
On a 390px Concepts viewport, the active tab was clipped to a single letter at the right edge. After the change, the full Concepts tab is visible and retains its active styling.

## Validation
- pnpm check
- pnpm verify:image-size-hardening
- pnpm --filter @stem-brain/web check:env:examples
- pnpm --filter @stem-brain/web build
- pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "concepts has its own navigation tab"
- git diff --check