### PR TITLE
fix(web): avoid clipped mobile wordmark

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -264,6 +264,11 @@ test.describe('browser smoke', () => {
     }
 
     await page.goto('/grid');
+    const homeLink = page.getByRole('link', { name: 'STEMBrain — go to home' });
+    const brandWordmark = page.getByTestId('brand-wordmark');
+    await expect(homeLink.locator('svg')).toBeVisible();
+    await expect(brandWordmark).toBeVisible();
+
     const conceptsTab = page.getByRole('link', { name: 'Concepts' });
     await expect(conceptsTab).toHaveAttribute('aria-current', 'page');
     await expect.poll(async () => {
@@ -279,6 +284,8 @@ test.describe('browser smoke', () => {
 
     if (exercisesViewportResize) {
       await page.setViewportSize({ width: 390, height: 844 });
+      await expect(brandWordmark).toBeHidden();
+      await expect(homeLink.locator('svg')).toBeVisible();
       await expect.poll(async () => {
         const box = await conceptsTab.boundingBox();
         return Boolean(box && box.x >= 0 && box.x + box.width <= 390);

--- a/apps/web/src/components/brand-logo.tsx
+++ b/apps/web/src/components/brand-logo.tsx
@@ -10,7 +10,10 @@ export default function BrandLogo({ className = '', textClassName = '', iconClas
   return (
     <span className={`inline-flex min-w-0 items-center gap-2 ${className}`.trim()}>
       <LogoMark className={`shrink-0 ${iconClassName}`.trim()} />
-      <span className={`truncate font-bold tracking-tight text-slate-900 ${textClassName}`.trim()}>
+      <span
+        data-testid="brand-wordmark"
+        className={`truncate font-bold tracking-tight text-slate-900 ${textClassName}`.trim()}
+      >
         STEM<span className="text-sky-600">Brain</span>
       </span>
     </span>

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -27,7 +27,9 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
         <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-3">
           <div className="flex min-w-0 items-center justify-between gap-3">
             <LocalizedLink href="/" aria-label={t('nav.homeLabel')} className="inline-flex min-w-0 items-center">
-              <BrandLogo textClassName={isHome ? 'text-xl !text-white' : 'text-xl'} />
+              <BrandLogo
+                textClassName={`${isHome ? '!text-white' : ''} hidden text-xl min-[480px]:inline`}
+              />
             </LocalizedLink>
 
             {user ? (


### PR DESCRIPTION
## Summary
- show the compact logo mark below 480px instead of a truncated STEMBrain wordmark
- preserve the localized accessible home-link name and full wordmark on wider screens
- cover the responsive wordmark state in the existing Concepts browser regression

## Validation
- `pnpm check`
- `pnpm --filter @stem-brain/web typecheck`
- `pnpm --filter @stem-brain/web lint`
- `pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "concepts has its own navigation tab" --project=chromium-desktop --project=chromium-mobile`
- `git diff --check`

## Render evidence
- verified at 390x844 that the wordmark is hidden, the logo mark remains visible, and the header actions and active Concepts tab stay fully visible