### PR TITLE
fix(web): align clipped active nav tabs

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -290,6 +290,8 @@ test.describe('browser smoke', () => {
         const box = await conceptsTab.boundingBox();
         return Boolean(box && box.x >= 0 && box.x + box.width <= 390);
       }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
+      const alignedConceptsBox = await conceptsTab.boundingBox();
+      expect(alignedConceptsBox?.x ?? Number.POSITIVE_INFINITY, 'active Concepts tab left alignment').toBeLessThanOrEqual(24);
     }
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
 

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -292,6 +292,18 @@ test.describe('browser smoke', () => {
       }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
       const alignedConceptsBox = await conceptsTab.boundingBox();
       expect(alignedConceptsBox?.x ?? Number.POSITIVE_INFINITY, 'active Concepts tab left alignment').toBeLessThanOrEqual(24);
+
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.locator('html').evaluate((element) => element.setAttribute('dir', 'rtl'));
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect.poll(async () => {
+        const box = await conceptsTab.boundingBox();
+        return Boolean(box && box.x + box.width >= 366 && box.x + box.width <= 390);
+      }, { message: 'active Concepts tab aligns to the logical start in RTL' }).toBe(true);
+
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.locator('html').evaluate((element) => element.setAttribute('dir', 'ltr'));
+      await page.setViewportSize({ width: 390, height: 844 });
     }
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
 

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -49,8 +49,7 @@ export default function NavLinks({
       const isClipped = activeRect.left < listRect.left || activeRect.right > listRect.right;
 
       if (isClipped) {
-        const listPadding = Number.parseFloat(getComputedStyle(navList).paddingInlineStart) || 0;
-        navList.scrollLeft += activeRect.left - listRect.left - listPadding;
+        activeLink.scrollIntoView({ block: 'nearest', inline: 'start' });
       }
     };
     const scheduleActiveLinkAlignment = () => {

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -40,7 +40,18 @@ export default function NavLinks({
   useEffect(() => {
     let animationFrame = 0;
     const keepActiveLinkVisible = () => {
-      activeLinkRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      const activeLink = activeLinkRef.current;
+      const navList = navListRef.current;
+      if (!activeLink || !navList) return;
+
+      const activeRect = activeLink.getBoundingClientRect();
+      const listRect = navList.getBoundingClientRect();
+      const isClipped = activeRect.left < listRect.left || activeRect.right > listRect.right;
+
+      if (isClipped) {
+        const listPadding = Number.parseFloat(getComputedStyle(navList).paddingInlineStart) || 0;
+        navList.scrollLeft += activeRect.left - listRect.left - listPadding;
+      }
     };
     const scheduleActiveLinkAlignment = () => {
       cancelAnimationFrame(animationFrame);


### PR DESCRIPTION
## Summary
- align a clipped active navigation tab to the scroll container start instead of leaving it at an edge
- preserve the current scroll position whenever the active tab is already fully visible
- assert the mobile Concepts tab lands on the header padding after a wide-to-narrow resize

## Validation
- `pnpm check`
- `pnpm --filter @stem-brain/web typecheck`
- `pnpm --filter @stem-brain/web lint`
- `pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "concepts has its own navigation tab" --project=chromium-desktop --project=chromium-mobile`
- `git diff --check`

## Render evidence
- at 390x844, the active Concepts tab moved from x=289.125 to x=20.125 and the clipped previous-tab fragment was replaced by complete following destinations