### PR TITLE
fix(web): keep home discipline chips stable

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -134,6 +134,18 @@ test.describe('browser smoke', () => {
     await page.goto('/');
     await expect(page.locator('main#main-content')).toBeVisible();
     await expect(page.getByRole('heading', { name: /Practice STEM concepts/i })).toBeVisible();
+    const disciplines = page.getByRole('list', { name: 'STEM disciplines' });
+    const disciplineItems = disciplines.getByRole('listitem');
+    await expect(disciplineItems).toHaveCount(8);
+    const disciplineLabels = await disciplineItems.allTextContents();
+    expect(new Set(disciplineLabels).size, 'home disciplines are not duplicated').toBe(disciplineLabels.length);
+
+    const viewport = page.viewportSize();
+    const disciplineBoxes = await disciplineItems.evaluateAll((items) => items.map((item) => {
+      const box = item.getBoundingClientRect();
+      return { left: box.left, right: box.right };
+    }));
+    expect(disciplineBoxes.every((box) => box.left >= 0 && box.right <= (viewport?.width ?? 0)), 'discipline chips stay inside the viewport').toBe(true);
 
     await assertNoBrowserFailures();
   });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -463,27 +463,6 @@ html {
   mix-blend-mode: screen;
 }
 
-.home-discipline-rail {
-  mask-image: linear-gradient(90deg, transparent 0%, black 8%, black 92%, transparent 100%);
-}
-
-.home-discipline-track {
-  animation: homeDisciplineCarousel 6s linear infinite;
-  will-change: transform;
-}
-
-.home-discipline-rail span {
-  animation: homeDisciplinePulse 7s ease-in-out infinite;
-}
-
-.home-discipline-rail span:nth-child(2n) {
-  animation-delay: 1.2s;
-}
-
-.home-discipline-rail span:nth-child(3n) {
-  animation-delay: 2.1s;
-}
-
 .home-status-pill {
   animation: homeStatusBlink 1.7s ease-in-out infinite;
 }
@@ -895,28 +874,6 @@ html {
   }
 }
 
-@keyframes homeDisciplinePulse {
-  0%,
-  100% {
-    border-color: rgba(255, 255, 255, 0.1);
-    color: rgb(203, 213, 225);
-  }
-  50% {
-    border-color: rgba(125, 211, 252, 0.3);
-    color: rgb(224, 242, 254);
-  }
-}
-
-@keyframes homeDisciplineCarousel {
-  from {
-    transform: translate3d(0, 0, 0);
-  }
-
-  to {
-    transform: translate3d(-50%, 0, 0);
-  }
-}
-
 @keyframes homeSpaceGridShift {
   from {
     background-position: 0 0, 0 0;
@@ -1107,10 +1064,8 @@ html {
   .home-graph-frame,
   .home-hero-copy,
   .home-hero-visual,
-  .home-discipline-track,
   .home-hero-constellation,
-  .home-hero-node,
-  .home-discipline-rail span {
+  .home-hero-node {
     animation: none;
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -93,15 +93,16 @@ export default async function HomePage() {
               {t('home.heroBody')}
             </p>
 
-            <div className="home-discipline-rail mt-7 max-w-3xl overflow-hidden text-xs font-semibold uppercase text-slate-300" aria-label={t('home.disciplinesAria')}>
-              <div className="home-discipline-track flex w-max gap-2">
-                {[...HOME_DISCIPLINES, ...HOME_DISCIPLINES].map((key, index) => (
-                  <span key={`${key}-${index}`} className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 backdrop-blur">
-                    {t(key)}
-                  </span>
-                ))}
-              </div>
-            </div>
+            <ul
+              className="mt-7 flex max-w-3xl flex-wrap gap-2 text-xs font-semibold uppercase text-slate-300"
+              aria-label={t('home.disciplinesAria')}
+            >
+              {HOME_DISCIPLINES.map((key) => (
+                <li key={key} className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 backdrop-blur">
+                  {t(key)}
+                </li>
+              ))}
+            </ul>
 
             <div className="mt-8 flex flex-wrap gap-3">
               {user ? (


### PR DESCRIPTION
## Summary
- replace the duplicated auto-scrolling discipline carousel with a stable semantic list
- wrap all eight complete discipline chips without clipping or motion
- remove the obsolete carousel, mask, pulse, and reduced-motion CSS
- verify item count, uniqueness, and viewport bounds in browser smoke coverage

## Validation
- `pnpm check`
- `pnpm --filter @stem-brain/web typecheck`
- `pnpm --filter @stem-brain/web lint`
- `pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "home page renders the app shell" --project=chromium-desktop --project=chromium-mobile`
- `git diff --check`

## Render evidence
- at 390x844 all eight disciplines render once across four stable rows, with every chip fully inside the viewport and the CTA group immediately below