### PR TITLE
fix(web): free mobile graph space

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -251,7 +251,7 @@ test.describe('browser smoke', () => {
     await assertNoBrowserFailures();
   });
 
-  test('knowledge graph renders a non-empty graph surface', async ({ page }) => {
+  test('knowledge graph renders a non-empty graph surface', async ({ page }, testInfo) => {
     const assertNoBrowserFailures = attachBrowserFailureGuards(page);
 
     await page.goto('/knowledge');
@@ -263,6 +263,32 @@ test.describe('browser smoke', () => {
     const box = await canvas.boundingBox();
     expect(box?.width ?? 0, 'knowledge graph canvas width').toBeGreaterThan(0);
     expect(box?.height ?? 0, 'knowledge graph canvas height').toBeGreaterThan(0);
+
+    const legend = page.getByTestId('graph-legend');
+    const legendContent = page.locator('#knowledge-graph-legend-content');
+    const legendToggle = page.getByRole('button', { name: 'Show legend' });
+
+    if (testInfo.project.name === 'chromium-mobile') {
+      await expect(legendToggle).toBeVisible();
+      await expect(legendToggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(legendContent).toBeHidden();
+
+      const controlsBox = await page.getByTestId('graph-controls').boundingBox();
+      const legendBox = await legend.boundingBox();
+      expect(
+        (legendBox?.y ?? 0) - ((controlsBox?.y ?? 0) + (controlsBox?.height ?? 0)),
+        'collapsed mobile legend leaves room to manipulate the graph',
+      ).toBeGreaterThan(350);
+
+      await legendToggle.click();
+      await expect(page.getByRole('button', { name: 'Hide legend' })).toHaveAttribute('aria-expanded', 'true');
+      await expect(legendContent).toBeVisible();
+      await page.getByRole('button', { name: 'Hide legend' }).click();
+      await expect(legendContent).toBeHidden();
+    } else {
+      await expect(legendToggle).toBeHidden();
+      await expect(legendContent).toBeVisible();
+    }
 
     await assertNoBrowserFailures();
   });

--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -283,6 +283,12 @@ test.describe('browser smoke', () => {
       await legendToggle.click();
       await expect(page.getByRole('button', { name: 'Hide legend' })).toHaveAttribute('aria-expanded', 'true');
       await expect(legendContent).toBeVisible();
+      expect(
+        await legendContent.evaluate((element) => element.scrollHeight > element.clientHeight),
+        'expanded mobile legend has a bounded scroll region',
+      ).toBe(true);
+      await legendContent.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+      await expect(legendContent.getByText('Moving particles and arrowheads show direction.')).toBeVisible();
       await page.getByRole('button', { name: 'Hide legend' }).click();
       await expect(legendContent).toBeHidden();
     } else {

--- a/apps/web/src/components/knowledge-graph-3d.tsx
+++ b/apps/web/src/components/knowledge-graph-3d.tsx
@@ -551,7 +551,7 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
 
         <div
           id="knowledge-graph-legend-content"
-          className={`${isLegendExpanded ? 'mt-3 block' : 'hidden'} md:mt-3 md:block`}
+          className={`${isLegendExpanded ? 'mt-3 block' : 'hidden'} max-h-60 overflow-y-auto pr-1 md:mt-3 md:block md:max-h-none md:overflow-visible md:pr-0`}
         >
           {colorMode === 'progress' ? (
             <>
@@ -586,7 +586,7 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
             </div>
             </>
           ) : (
-            <div className="max-h-64 space-y-1.5 overflow-y-auto pr-1 md:max-h-96">
+            <div className="space-y-1.5 md:max-h-96 md:overflow-y-auto md:pr-1">
               {visibleDomainList
                 .filter((domain) => domain !== 'other')
                 .map((domain) => {

--- a/apps/web/src/components/knowledge-graph-3d.tsx
+++ b/apps/web/src/components/knowledge-graph-3d.tsx
@@ -93,6 +93,7 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
   const [selectedDomain, setSelectedDomain] = useState<string | 'all'>('all');
   const [selectedStatus, setSelectedStatus] = useState<CardStatus | 'all' | 'unstarted'>('all');
   const [colorMode, setColorMode] = useState<ColorMode>('progress');
+  const [isLegendExpanded, setIsLegendExpanded] = useState(false);
   const fgRef = useRef<any>(null);
 
   const getStatusLabel = (status: CardStatus | null) => {
@@ -374,7 +375,10 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
 
       {/* Top bar */}
       <div className="absolute top-0 left-0 right-0 z-20 flex items-start justify-between gap-3 px-4 py-4 md:px-6 pointer-events-none">
-        <div className="pointer-events-auto w-[min(34rem,calc(100vw-2rem))] rounded-xl border border-gray-800 bg-gray-950/80 p-3 backdrop-blur-sm shadow-lg">
+        <div
+          data-testid="graph-controls"
+          className="pointer-events-auto w-[min(34rem,calc(100vw-2rem))] rounded-xl border border-gray-800 bg-gray-950/80 p-3 backdrop-blur-sm shadow-lg"
+        >
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold text-white tracking-tight">
@@ -521,10 +525,36 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
       </div>
 
       {/* Legend - bottom left */}
-      <div className="pointer-events-auto absolute bottom-4 left-4 right-4 z-10 max-h-80 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/85 p-4 shadow-xl backdrop-blur-sm md:bottom-6 md:left-6 md:right-auto md:w-72 md:max-h-[28rem]">
-        {colorMode === 'progress' ? (
-          <>
-            <p className="text-[10px] uppercase tracking-widest text-gray-500 mb-3 font-semibold">{t('graph.progressColors')}</p>
+      <div
+        data-testid="graph-legend"
+        className="pointer-events-auto absolute bottom-4 left-4 right-4 z-10 max-h-80 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/85 p-3 shadow-xl backdrop-blur-sm md:bottom-6 md:left-6 md:right-auto md:w-72 md:max-h-[28rem] md:p-4"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-gray-500">
+            {colorMode === 'progress' ? t('graph.progressColors') : t('graph.domainColors')}
+          </p>
+          <div className="flex items-center gap-3">
+            {colorMode === 'domain' && (
+              <span className="hidden text-[10px] text-gray-500 md:inline">{t('graph.clickInspect')}</span>
+            )}
+            <button
+              type="button"
+              aria-controls="knowledge-graph-legend-content"
+              aria-expanded={isLegendExpanded}
+              onClick={() => setIsLegendExpanded((expanded) => !expanded)}
+              className="rounded-md border border-gray-700 bg-black/20 px-2.5 py-1.5 text-xs font-medium text-gray-300 transition-colors hover:bg-white/10 md:hidden"
+            >
+              {isLegendExpanded ? t('graph.hideLegend') : t('graph.showLegend')}
+            </button>
+          </div>
+        </div>
+
+        <div
+          id="knowledge-graph-legend-content"
+          className={`${isLegendExpanded ? 'mt-3 block' : 'hidden'} md:mt-3 md:block`}
+        >
+          {colorMode === 'progress' ? (
+            <>
             <div className="space-y-2">
               {[
                 { label: t('common.explainable'), color: STATUS_COLORS.known },
@@ -554,13 +584,8 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
               </div>
               <p className="mt-2 text-[10px] leading-relaxed text-gray-500">{t('graph.directionHint')}</p>
             </div>
-          </>
-        ) : (
-          <>
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <p className="text-[10px] uppercase tracking-widest text-gray-500 font-semibold">{t('graph.domainColors')}</p>
-              <span className="text-[10px] text-gray-500">{t('graph.clickInspect')}</span>
-            </div>
+            </>
+          ) : (
             <div className="max-h-64 space-y-1.5 overflow-y-auto pr-1 md:max-h-96">
               {visibleDomainList
                 .filter((domain) => domain !== 'other')
@@ -592,8 +617,8 @@ export default function KnowledgeGraph3D({ cards, edges = [], onClose }: Props) 
                   );
                 })}
             </div>
-          </>
-        )}
+          )}
+        </div>
       </div>
 
       {/* Node Detail Panel - slides in from right */}

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -408,6 +408,8 @@ export const AR_MESSAGES = {
   "graph.backToConcepts": "العودة إلى المفاهيم",
   "graph.progressColors": "ألوان التقدم",
   "graph.domainColors": "ألوان المجالات",
+  "graph.showLegend": "إظهار وسيلة الإيضاح",
+  "graph.hideLegend": "إخفاء وسيلة الإيضاح",
   "graph.clickInspect": "انقر للاستكشاف",
   "graph.domainHub": "محور المجال",
   "graph.domainColor": "لون المجال",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -409,6 +409,8 @@ export const EN_MESSAGES = {
   "graph.backToConcepts": "Back to Concepts",
   "graph.progressColors": "Progress Colors",
   "graph.domainColors": "Domain Colors",
+  "graph.showLegend": "Show legend",
+  "graph.hideLegend": "Hide legend",
   "graph.clickInspect": "Click to inspect",
   "graph.domainHub": "Domain Hub",
   "graph.domainColor": "Domain color",

--- a/apps/web/src/i18n/catalogs/es.ts
+++ b/apps/web/src/i18n/catalogs/es.ts
@@ -408,6 +408,8 @@ export const ES_MESSAGES = {
   "graph.backToConcepts": "Volver a los conceptos",
   "graph.progressColors": "Colores de progreso",
   "graph.domainColors": "Colores de los campos",
+  "graph.showLegend": "Mostrar leyenda",
+  "graph.hideLegend": "Ocultar leyenda",
   "graph.clickInspect": "Haz clic para ver los detalles",
   "graph.domainHub": "Centro del campo",
   "graph.domainColor": "Color del campo",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -408,6 +408,8 @@ export const HI_MESSAGES = {
   "graph.backToConcepts": "अवधारणाओं पर वापस जाएँ",
   "graph.progressColors": "प्रगति के रंग",
   "graph.domainColors": "क्षेत्रों के रंग",
+  "graph.showLegend": "संकेत दिखाएँ",
+  "graph.hideLegend": "संकेत छिपाएँ",
   "graph.clickInspect": "जाँचने के लिए क्लिक करें",
   "graph.domainHub": "क्षेत्र केंद्र",
   "graph.domainColor": "क्षेत्र का रंग",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -394,6 +394,8 @@ export const JA_MESSAGES = {
   "graph.backToConcepts": "概念に戻る",
   "graph.progressColors": "進捗の色",
   "graph.domainColors": "分野の色",
+  "graph.showLegend": "凡例を表示",
+  "graph.hideLegend": "凡例を非表示",
   "graph.clickInspect": "クリックして詳細表示",
   "graph.domainHub": "分野ハブ",
   "graph.domainColor": "分野カラー",

--- a/apps/web/src/i18n/catalogs/zh-CN.ts
+++ b/apps/web/src/i18n/catalogs/zh-CN.ts
@@ -407,6 +407,8 @@ export const ZH_CN_MESSAGES = {
   "graph.backToConcepts": "返回概念",
   "graph.progressColors": "进度颜色",
   "graph.domainColors": "领域颜色",
+  "graph.showLegend": "显示图例",
+  "graph.hideLegend": "隐藏图例",
   "graph.clickInspect": "点击查看",
   "graph.domainHub": "领域中心",
   "graph.domainColor": "领域颜色",


### PR DESCRIPTION
## Summary
- collapse the large Knowledge Graph legend by default on mobile while keeping the desktop legend expanded
- add localized, accessible show/hide controls across all supported web locales
- verify the collapsed layout preserves a substantial graph interaction region and that the legend remains operable

## Validation
- pnpm --filter @stem-brain/web typecheck
- pnpm --filter @stem-brain/web lint
- pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "knowledge graph renders a non-empty graph surface" --project=chromium-desktop --project=chromium-mobile
- pnpm check
- git diff --check