### PR TITLE
fix(web): enlarge practice navigation targets

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -187,6 +187,15 @@ test.describe('browser smoke', () => {
 
     await page.goto('/practice');
 
+    for (const control of [
+      page.getByRole('button', { name: 'Go to previous card' }),
+      page.getByRole('button', { name: 'Skip this card' }),
+    ]) {
+      const box = await control.boundingBox();
+      expect(box?.width ?? 0, 'practice navigation touch target width').toBeGreaterThanOrEqual(44);
+      expect(box?.height ?? 0, 'practice navigation touch target height').toBeGreaterThanOrEqual(44);
+    }
+
     const revealButton = page.getByRole('button', { name: 'Show answer' });
     await expect(revealButton).toHaveAttribute('aria-expanded', 'false');
     await revealButton.click();

--- a/apps/web/src/components/card-viewer.tsx
+++ b/apps/web/src/components/card-viewer.tsx
@@ -422,7 +422,7 @@ export default function CardViewer({
           onClick={handlePrevious}
           disabled={history.length === 0 || loading}
           aria-label={t('practice.previousAria')}
-          className="text-sm text-gray-500 hover:text-gray-900 disabled:opacity-30 flex items-center gap-1 transition-colors rounded-lg px-2 py-1 hover:bg-gray-100 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="flex min-h-11 items-center gap-1 rounded-lg px-3 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:pointer-events-none disabled:opacity-30"
         >
           {t('practice.previous')}
         </button>
@@ -430,7 +430,7 @@ export default function CardViewer({
           onClick={handleSkip}
           disabled={loading}
           aria-label={t('practice.skipAria')}
-          className="text-sm text-gray-500 hover:text-gray-900 flex items-center gap-1 transition-colors rounded-lg px-2 py-1 hover:bg-gray-100 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="flex min-h-11 items-center gap-1 rounded-lg px-3 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
         >
           {loading ? '…' : t('practice.skip')}
         </button>


### PR DESCRIPTION
## Summary
- enlarge Previous and Skip to minimum 44px touch targets in practice
- preserve their existing visual hierarchy and disabled behavior
- add browser regression coverage for both target dimensions on desktop and mobile

## Validation
- pnpm --filter @stem-brain/web typecheck
- pnpm --filter @stem-brain/web lint
- pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "practice answer control exposes its reveal state" --project=chromium-desktop --project=chromium-mobile
- pnpm check
- git diff --check