### PR TITLE
fix(web): enlarge main navigation targets

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -345,6 +345,8 @@ test.describe('browser smoke', () => {
       }, { message: 'active Concepts navigation tab stays visible after resize' }).toBe(true);
       const alignedConceptsBox = await conceptsTab.boundingBox();
       expect(alignedConceptsBox?.x ?? Number.POSITIVE_INFINITY, 'active Concepts tab left alignment').toBeLessThanOrEqual(24);
+      expect(alignedConceptsBox?.width ?? 0, 'main navigation touch target width').toBeGreaterThanOrEqual(44);
+      expect(alignedConceptsBox?.height ?? 0, 'main navigation touch target height').toBeGreaterThanOrEqual(44);
 
       await page.setViewportSize({ width: 1440, height: 900 });
       await page.locator('html').evaluate((element) => element.setAttribute('dir', 'rtl'));

--- a/apps/web/src/components/nav-links.tsx
+++ b/apps/web/src/components/nav-links.tsx
@@ -85,7 +85,7 @@ export default function NavLinks({
                 href={item.href}
                 ref={active ? activeLinkRef : undefined}
                 aria-current={active ? 'page' : undefined}
-                className={`inline-flex min-h-8 items-center rounded-md px-3 py-1.5 transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'focus:ring-offset-slate-950' : 'focus:ring-offset-2 focus:ring-offset-white'} ${
+                className={`inline-flex min-h-11 items-center rounded-md px-3 py-1.5 transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'focus:ring-offset-slate-950' : 'focus:ring-offset-2 focus:ring-offset-white'} ${
                   active
                     ? isHome ? 'bg-white/12 text-cyan-100 shadow-sm ring-1 ring-white/10' : 'bg-white text-blue-700 shadow-sm ring-1 ring-slate-200'
                     : isHome ? 'hover:bg-white/10 hover:text-white' : 'hover:bg-white/70 hover:text-slate-950'
@@ -100,7 +100,7 @@ export default function NavLinks({
           <li className="shrink-0">
             <LocalizedLink
               href="/admin/ops"
-              className={`inline-flex min-h-8 items-center rounded-md border px-3 py-1.5 transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-cyan-300/30 bg-cyan-300/10 text-cyan-100 hover:bg-cyan-300/20 focus:ring-offset-slate-950' : 'border-cyan-200 bg-cyan-50 text-cyan-800 hover:bg-cyan-100 focus:ring-offset-2 focus:ring-offset-white'}`}
+              className={`inline-flex min-h-11 items-center rounded-md border px-3 py-1.5 transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-cyan-300/30 bg-cyan-300/10 text-cyan-100 hover:bg-cyan-300/20 focus:ring-offset-slate-950' : 'border-cyan-200 bg-cyan-50 text-cyan-800 hover:bg-cyan-100 focus:ring-offset-2 focus:ring-offset-white'}`}
             >
               {t('nav.adminOps')}
             </LocalizedLink>


### PR DESCRIPTION
## Summary
- increase main navigation tabs, including admin operations, to a 44px minimum height
- preserve horizontal overflow and logical active-tab alignment
- add mobile browser coverage for the active tab touch target

## UX evidence
- production before: Concepts tab measured 84.97 × 32px at 390px width
- local after: Concepts tab measured 84.97 × 44px and remained fully visible/current

## Validation
- `pnpm check`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "concepts has its own navigation tab"` (desktop + mobile)
- `git diff --check`