### PR TITLE
fix(web): enlarge header utility targets

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -339,6 +339,16 @@ test.describe('browser smoke', () => {
       await page.setViewportSize({ width: 390, height: 844 });
       await expect(brandWordmark).toBeHidden();
       await expect(homeLink.locator('svg')).toBeVisible();
+      for (const control of [
+        homeLink,
+        page.getByRole('combobox', { name: 'Choose language' }),
+        page.getByRole('link', { name: 'Log in' }),
+        page.getByRole('link', { name: 'Sign up' }),
+      ]) {
+        const box = await control.boundingBox();
+        expect(box?.width ?? 0, 'site header touch target width').toBeGreaterThanOrEqual(44);
+        expect(box?.height ?? 0, 'site header touch target height').toBeGreaterThanOrEqual(44);
+      }
       await expect.poll(async () => {
         const box = await conceptsTab.boundingBox();
         return Boolean(box && box.x >= 0 && box.x + box.width <= 390);

--- a/apps/web/e2e/localization.spec.ts
+++ b/apps/web/e2e/localization.spec.ts
@@ -67,8 +67,13 @@ test.describe('localized web routes', () => {
   });
 
   for (const { locale, direction, script } of LOCALE_CASES) {
-    test(`${locale} renders its localized document and home copy`, async ({ page }) => {
+    test(`${locale} renders its localized document and home copy`, async ({ page }, testInfo) => {
       const i18n = createI18n(locale);
+      const exercisesMobileHeader = testInfo.project.name === 'chromium-mobile';
+
+      if (exercisesMobileHeader) {
+        await page.setViewportSize({ width: 360, height: 844 });
+      }
 
       await page.goto(`/${locale}`);
 
@@ -81,6 +86,21 @@ test.describe('localized web routes', () => {
       await expect(heading).toBeVisible();
       expect(await heading.textContent()).toMatch(script);
       await expect(page.getByRole('combobox', { name: i18n.t('locale.select') })).toHaveValue(locale);
+      if (exercisesMobileHeader) {
+        const siteHeader = page.getByRole('navigation', { name: i18n.t('nav.siteHeader') });
+        for (const control of [
+          siteHeader.getByRole('link', { name: i18n.t('nav.homeLabel') }),
+          siteHeader.getByRole('combobox', { name: i18n.t('locale.select') }),
+          siteHeader.getByRole('link', { name: i18n.t('nav.login') }),
+          siteHeader.getByRole('link', { name: i18n.t('nav.signup') }),
+        ]) {
+          const box = await control.boundingBox();
+          expect(box?.width ?? 0, `${locale} header target width`).toBeGreaterThanOrEqual(44);
+          expect(box?.height ?? 0, `${locale} header target height`).toBeGreaterThanOrEqual(44);
+          expect(box?.x ?? Number.NEGATIVE_INFINITY, `${locale} header target left edge`).toBeGreaterThanOrEqual(0);
+          expect((box?.x ?? 360) + (box?.width ?? 1), `${locale} header target right edge`).toBeLessThanOrEqual(360);
+        }
+      }
       await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', `https://www.girapphe.com/${locale}`);
       await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveAttribute(
         'href',

--- a/apps/web/src/components/language-switcher.tsx
+++ b/apps/web/src/components/language-switcher.tsx
@@ -40,7 +40,7 @@ export default function LanguageSwitcher({ compact = false }: { compact?: boolea
         value={locale}
         aria-label={t('locale.select')}
         onChange={(event) => changeLocale(event.target.value as Locale)}
-        className="max-w-36 rounded-md border border-current/20 bg-transparent px-2 py-1.5 text-xs font-medium outline-none transition focus:ring-2 focus:ring-blue-500"
+        className="min-h-11 max-w-36 rounded-md border border-current/20 bg-transparent px-2 py-1.5 text-xs font-medium outline-none transition focus:ring-2 focus:ring-blue-500"
       >
         {SUPPORTED_LOCALES.map((supportedLocale) => (
           <option key={supportedLocale} value={supportedLocale} className="bg-white text-slate-900">

--- a/apps/web/src/components/language-switcher.tsx
+++ b/apps/web/src/components/language-switcher.tsx
@@ -40,7 +40,7 @@ export default function LanguageSwitcher({ compact = false }: { compact?: boolea
         value={locale}
         aria-label={t('locale.select')}
         onChange={(event) => changeLocale(event.target.value as Locale)}
-        className="min-h-11 max-w-36 rounded-md border border-current/20 bg-transparent px-2 py-1.5 text-xs font-medium outline-none transition focus:ring-2 focus:ring-blue-500"
+        className={`${compact ? 'w-[4.75rem]' : 'max-w-36'} min-h-11 rounded-md border border-current/20 bg-transparent px-2 py-1.5 text-xs font-medium outline-none transition focus:ring-2 focus:ring-blue-500`}
       >
         {SUPPORTED_LOCALES.map((supportedLocale) => (
           <option key={supportedLocale} value={supportedLocale} className="bg-white text-slate-900">

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -26,7 +26,7 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
       >
         <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-3">
           <div className="flex min-w-0 items-center justify-between gap-3">
-            <LocalizedLink href="/" aria-label={t('nav.homeLabel')} className="inline-flex min-w-0 items-center">
+            <LocalizedLink href="/" aria-label={t('nav.homeLabel')} className="inline-flex min-h-11 min-w-11 items-center justify-center">
               <BrandLogo
                 textClassName={`${isHome ? '!text-white' : ''} hidden text-xl min-[480px]:inline`}
               />
@@ -45,7 +45,7 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
                   <button
                     type="submit"
                     aria-label={t('nav.logoutAria')}
-                    className={`rounded-md border px-3 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}
+                    className={`inline-flex min-h-11 items-center justify-center rounded-md border px-3 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}
                   >
                     {t('nav.logout')}
                   </button>
@@ -54,10 +54,10 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
             ) : (
               <div className="flex shrink-0 items-center gap-2 text-sm font-medium">
                 <LanguageSwitcher compact />
-                <LocalizedLink href="/login" className={`rounded-md border px-3 py-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}>
+                <LocalizedLink href="/login" className={`inline-flex min-h-11 items-center justify-center rounded-md border px-3 py-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}>
                   {t('nav.login')}
                 </LocalizedLink>
-                <LocalizedLink href="/signup" className={`rounded-md px-3 py-1.5 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 ${isHome ? 'bg-cyan-500 hover:bg-cyan-400' : 'bg-blue-600 hover:bg-blue-700'}`}>
+                <LocalizedLink href="/signup" className={`inline-flex min-h-11 items-center justify-center rounded-md px-3 py-1.5 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 ${isHome ? 'bg-cyan-500 hover:bg-cyan-400' : 'bg-blue-600 hover:bg-blue-700'}`}>
                   {t('nav.signup')}
                 </LocalizedLink>
               </div>

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -25,15 +25,15 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
         className={`sticky top-0 z-40 overflow-hidden border-b px-4 py-3 backdrop-blur ${isHome ? 'border-white/10 bg-slate-950/60 text-white shadow-[0_10px_40px_rgba(2,6,23,0.18)]' : 'border-slate-200 bg-white/95 text-slate-800'}`}
       >
         <div className="mx-auto flex w-full max-w-6xl min-w-0 flex-col gap-3">
-          <div className="flex min-w-0 items-center justify-between gap-3">
-            <LocalizedLink href="/" aria-label={t('nav.homeLabel')} className="inline-flex min-h-11 min-w-11 items-center justify-center">
+          <div className="flex min-w-0 items-center justify-between gap-2 min-[400px]:gap-3">
+            <LocalizedLink href="/" aria-label={t('nav.homeLabel')} className="-mx-2 inline-flex min-h-11 min-w-11 items-center justify-center">
               <BrandLogo
                 textClassName={`${isHome ? '!text-white' : ''} hidden text-xl min-[480px]:inline`}
               />
             </LocalizedLink>
 
             {user ? (
-              <div className="flex shrink-0 items-center gap-2 text-sm font-medium">
+              <div className="flex shrink-0 items-center gap-1 text-sm font-medium min-[400px]:gap-2">
                 <LanguageSwitcher compact />
                 <span
                   className={`hidden rounded-md px-2 py-1 text-xs md:inline ${isHome ? 'bg-white/10 text-slate-300' : 'bg-slate-100 text-slate-600'}`}
@@ -45,19 +45,19 @@ export default async function Navbar({ user: initialUser, variant = 'default' }:
                   <button
                     type="submit"
                     aria-label={t('nav.logoutAria')}
-                    className={`inline-flex min-h-11 items-center justify-center rounded-md border px-3 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}
+                    className={`inline-flex min-h-11 items-center justify-center rounded-md border px-2 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 min-[400px]:px-3 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}
                   >
                     {t('nav.logout')}
                   </button>
                 </form>
               </div>
             ) : (
-              <div className="flex shrink-0 items-center gap-2 text-sm font-medium">
+              <div className="flex shrink-0 items-center gap-1 text-sm font-medium min-[400px]:gap-2">
                 <LanguageSwitcher compact />
-                <LocalizedLink href="/login" className={`inline-flex min-h-11 items-center justify-center rounded-md border px-3 py-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}>
+                <LocalizedLink href="/login" className={`inline-flex min-h-11 items-center justify-center rounded-md border px-2 py-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 min-[400px]:px-3 ${isHome ? 'border-white/20 text-white hover:bg-white/10' : 'hover:bg-gray-50'}`}>
                   {t('nav.login')}
                 </LocalizedLink>
-                <LocalizedLink href="/signup" className={`inline-flex min-h-11 items-center justify-center rounded-md px-3 py-1.5 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 ${isHome ? 'bg-cyan-500 hover:bg-cyan-400' : 'bg-blue-600 hover:bg-blue-700'}`}>
+                <LocalizedLink href="/signup" className={`inline-flex min-h-11 items-center justify-center rounded-md px-2 py-1.5 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 min-[400px]:px-3 ${isHome ? 'bg-cyan-500 hover:bg-cyan-400' : 'bg-blue-600 hover:bg-blue-700'}`}>
                   {t('nav.signup')}
                 </LocalizedLink>
               </div>


### PR DESCRIPTION
## Summary
- give the home brand, language selector, login, signup, and logout controls a 44px minimum touch target
- keep the compact mobile header layout and existing focus styling
- add mobile browser assertions for every public header utility

## UX evidence
- production before at 390px: home 28px, language 33px, login 34px, signup 32px high
- local after: all four public header controls measure exactly 44px high; home is also 44px wide

## Validation
- `pnpm check`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 pnpm exec playwright test apps/web/e2e/browser-smoke.spec.ts --grep "concepts has its own navigation tab"` (desktop + mobile)
- `git diff --check`