### PR TITLE
fix(web): enlarge concept card actions

### DIFF
--- a/apps/web/e2e/browser-smoke.spec.ts
+++ b/apps/web/e2e/browser-smoke.spec.ts
@@ -371,6 +371,10 @@ test.describe('browser smoke', () => {
       await page.setViewportSize({ width: 390, height: 844 });
     }
     await expect(page.getByRole('heading', { name: 'Concepts' })).toBeVisible();
+    const wikiLink = page.getByRole('link', { name: 'Wiki →' }).first();
+    const wikiLinkBox = await wikiLink.boundingBox();
+    expect(wikiLinkBox?.width ?? 0, 'concept source touch target width').toBeGreaterThanOrEqual(44);
+    expect(wikiLinkBox?.height ?? 0, 'concept source touch target height').toBeGreaterThanOrEqual(44);
 
     const groupBy = page.getByLabel('Group by');
     await expect(groupBy).toHaveValue('domain');
@@ -456,6 +460,16 @@ test.describe('browser smoke', () => {
     const editor = firstCard.getByTestId('concept-card-editor');
     await expect(editor).toBeVisible();
     await expect(editor.getByText('Edits to public concepts are saved as a private copy.')).toBeVisible();
+    for (const control of [
+      editor.getByLabel('Title'),
+      editor.getByLabel('Topic'),
+      editor.getByLabel('Tags'),
+      editor.getByRole('button', { name: 'Save private copy' }),
+      editor.getByRole('button', { name: 'Cancel' }),
+    ]) {
+      const box = await control.boundingBox();
+      expect(box?.height ?? 0, 'concept editor touch target height').toBeGreaterThanOrEqual(44);
+    }
     await editor.getByLabel('Title').fill('   ');
     await editor.getByRole('button', { name: 'Save private copy' }).click();
     await expect(editor.getByRole('alert')).toHaveText('Enter a title before saving.');

--- a/apps/web/src/components/knowledge-map.tsx
+++ b/apps/web/src/components/knowledge-map.tsx
@@ -765,7 +765,7 @@ function KnowledgeCardItem({
           href={card.wiki_url}
           target="_blank"
           rel="noopener noreferrer"
-          className="relative z-10 text-xs text-blue-700 hover:text-blue-800 hover:underline transition-colors"
+          className="relative z-10 inline-flex min-h-11 min-w-11 items-center text-xs text-blue-700 transition-colors hover:text-blue-800 hover:underline"
         >
           {t('knowledge.wiki')}
         </a>
@@ -777,7 +777,7 @@ function KnowledgeCardItem({
             label={t('knowledge.moveTrash')}
             confirmMessage={t('knowledge.moveTrashConfirm', { title: card.title, days: 14 })}
             ariaLabel={t('knowledge.moveTrashAria', { title: card.title })}
-            className="rounded-md border border-red-200 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+            className="min-h-11 rounded-md border border-red-200 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
           />
         </form>
       ) : null}
@@ -793,11 +793,11 @@ function KnowledgeCardItem({
           </p>
           <label className="grid gap-1 text-xs font-medium text-gray-700">
             {t('notes.titleLabel')}
-            <input ref={titleInputRef} name="title" required defaultValue={card.title} className="rounded border bg-white px-3 py-2 text-sm" />
+            <input ref={titleInputRef} name="title" required defaultValue={card.title} className="min-h-11 rounded border bg-white px-3 py-2 text-sm" />
           </label>
           <label className="grid gap-1 text-xs font-medium text-gray-700">
             {t('notes.newTopic')}
-            <input name="topic" defaultValue={card.domains?.[0] ?? card.domain} className="rounded border bg-white px-3 py-2 text-sm" />
+            <input name="topic" defaultValue={card.domains?.[0] ?? card.domain} className="min-h-11 rounded border bg-white px-3 py-2 text-sm" />
           </label>
           <label className="grid gap-1 text-xs font-medium text-gray-700">
             {t('knowledge.summaryLabel')}
@@ -809,14 +809,14 @@ function KnowledgeCardItem({
           </label>
           <label className="grid gap-1 text-xs font-medium text-gray-700">
             {t('knowledge.tagsLabel')}
-            <input name="tags" defaultValue={card.tags?.join(', ') ?? ''} maxLength={599} className="rounded border bg-white px-3 py-2 text-sm" />
+            <input name="tags" defaultValue={card.tags?.join(', ') ?? ''} maxLength={599} className="min-h-11 rounded border bg-white px-3 py-2 text-sm" />
           </label>
           {saveError ? <p role="alert" className="text-xs text-red-700">{saveError}</p> : null}
           <div className="flex flex-wrap gap-2">
             <button
               type="submit"
               disabled={isSaving}
-              className="rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-60"
+              className="min-h-11 rounded bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-60"
             >
               {isSaving ? t('common.saving') : card.personalItemId ? t('notes.save') : t('knowledge.savePrivateCopy')}
             </button>
@@ -824,7 +824,7 @@ function KnowledgeCardItem({
               type="button"
               onClick={() => setEditing(false)}
               disabled={isSaving}
-              className="rounded border px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+              className="min-h-11 rounded border px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
             >
               {t('common.cancel')}
             </button>


### PR DESCRIPTION
## Summary
- make concept source links and trash actions finger-friendly
- give card editor text inputs and save/cancel actions a 44px minimum touch height
- add rendered desktop and mobile regression coverage for source and editor controls

## Validation
- `pnpm browser:smoke --grep "concepts has its own navigation tab|concept cards save public edits"` (4 passed)
- `pnpm check` (4 packages passed)
- `git diff --check`